### PR TITLE
CON-59: Restrict access to Concourse connection info via reflection

### DIFF
--- a/concourse-shell/src/main/java/org/cinchapi/concourse/shell/ConcourseShell.java
+++ b/concourse-shell/src/main/java/org/cinchapi/concourse/shell/ConcourseShell.java
@@ -325,7 +325,7 @@ public final class ConcourseShell {
      */
     private static List<String> BANNED_CHAR_SEQUENCES = Lists.newArrayList(
             "concourse.exit()", "concourse.username", "concourse.password",
-            "concourse.client");
+            "concourse.client", "concourse.getClass().getDeclaredFields()");
 
     /**
      * A list which contains all of the accessible API methods. This list is


### PR DESCRIPTION
I thought about the approach suggested to use a security manager and restrict access to the concourse connection metadata , however it would be rather simple to just restrict the end user to execute a command which tries to use reflection and get access to the private fields of the concourse client. So I added it to the list of banned commands and so the user won't be able to execute it. 