### PR TITLE
CON-259: Fix historical reads in the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * Fixed a bug that caused transactions to prematurely fail if an embedded atomic operation didn't succeed ([CON-263](https://cinchapi.atlassian.net/browse/CON-263)).
 * Java Driver: Fixed an issue in the where the client would throw an Exception if a call was made to the `commit()` method when a transaction was not in progress. Now the client will simply return `false` in this case.
 * Fixed an issue that caused the `concourse` and `cash` scripts to fail when added to the $PATH on certain Debian systems that did not have `sh` installed.
+* Fixed an issue where historical reads when queried with future timestamps would violate the ACID property by allowing the phantom read phenomenon to happen ([CON-259](https://cinchapi.atlassian.net/browse/CON-259)).
 
 #### Version 0.4.4 (March 2, 2015)
 * Fixed an issue where transactions and atomic operations unnecessarily performed pre-commit locking during read operations, which negatively impacted performance and violated the just-in-time locking protocol ([CON-198/CON-199](https://cinchapi.atlassian.net/browse/CON-199)).

--- a/concourse-server/src/main/java/org/cinchapi/concourse/server/storage/AtomicOperation.java
+++ b/concourse-server/src/main/java/org/cinchapi/concourse/server/storage/AtomicOperation.java
@@ -39,6 +39,7 @@ import org.cinchapi.concourse.server.model.Value;
 import org.cinchapi.concourse.server.storage.temp.Queue;
 import org.cinchapi.concourse.thrift.Operator;
 import org.cinchapi.concourse.thrift.TObject;
+import org.cinchapi.concourse.time.Time;
 import org.cinchapi.concourse.util.ByteBuffers;
 import org.cinchapi.concourse.util.Transformers;
 
@@ -243,8 +244,13 @@ public class AtomicOperation extends BufferedStore implements
     @Override
     public Map<String, Set<TObject>> select(long record, long timestamp)
             throws AtomicStateException {
-        checkState();
-        return super.select(record, timestamp);
+        if(timestamp > Time.now()) {
+            return select(record);
+        }
+        else {
+            checkState();
+            return super.select(record, timestamp);
+        }
     }
 
     @Override
@@ -265,8 +271,13 @@ public class AtomicOperation extends BufferedStore implements
     @Override
     public Map<TObject, Set<Long>> browse(String key, long timestamp)
             throws AtomicStateException {
-        checkState();
-        return super.browse(key, timestamp);
+        if(timestamp > Time.now()) {
+            return browse(key);
+        }
+        else {
+            checkState();
+            return super.browse(key, timestamp);
+        }
     }
 
     /**
@@ -322,8 +333,13 @@ public class AtomicOperation extends BufferedStore implements
     @Override
     public Set<TObject> select(String key, long record, long timestamp)
             throws AtomicStateException {
-        checkState();
-        return super.select(key, record, timestamp);
+        if(timestamp > Time.now()) {
+            return select(key, record);
+        }
+        else {
+            checkState();
+            return super.select(key, record, timestamp);
+        }
     }
 
     @Override
@@ -413,8 +429,13 @@ public class AtomicOperation extends BufferedStore implements
     @Override
     public boolean verify(String key, TObject value, long record, long timestamp)
             throws AtomicStateException {
-        checkState();
-        return super.verify(key, value, record, timestamp);
+        if(timestamp > Time.now()) {
+            return verify(key, value, record);
+        }
+        else {
+            checkState();
+            return super.verify(key, value, record, timestamp);
+        }
     }
 
     /**
@@ -601,8 +622,13 @@ public class AtomicOperation extends BufferedStore implements
     @Override
     protected Map<Long, Set<TObject>> doExplore(long timestamp, String key,
             Operator operator, TObject... values) {
-        checkState();
-        return super.doExplore(timestamp, key, operator, values);
+        if(timestamp > Time.now()) {
+            return doExplore(key, operator, values);
+        }
+        else {
+            checkState();
+            return super.doExplore(timestamp, key, operator, values);
+        }
     }
 
     @Override

--- a/concourse-server/src/test/java/org/cinchapi/concourse/server/storage/EngineAtomicOperationTest.java
+++ b/concourse-server/src/test/java/org/cinchapi/concourse/server/storage/EngineAtomicOperationTest.java
@@ -133,6 +133,73 @@ public class EngineAtomicOperationTest extends AtomicOperationTest {
 
     }
 
+    @Test(expected = AtomicStateException.class)
+    public void testNoPhantomReadWithTimestampInTheFutureUsingSelect() {
+        long aheadOfTime = Time.now() + (long) 10e9;
+        String key = Variables.register("key", TestData.getSimpleString());
+        TObject value = Variables.register("value", TestData.getTObject());
+        long record = Variables.register("record", TestData.getLong());
+
+        AtomicOperation atomicOp = (AtomicOperation) store;
+        atomicOp.select(record, aheadOfTime);
+        destination.accept(Write.add(key, value, record));
+        atomicOp.select(record, aheadOfTime);
+    }
+
+    @Test(expected = AtomicStateException.class)
+    public void testNoPhantomReadWithTimestampInTheFutureUsingSelectWithKey() {
+        long aheadOfTime = Time.now() + (long) 10e9;
+        String key = Variables.register("key", TestData.getSimpleString());
+        TObject value = Variables.register("value", TestData.getTObject());
+        long record = Variables.register("record", TestData.getLong());
+
+        AtomicOperation atomicOp = (AtomicOperation) store;
+        atomicOp.select(key, record, aheadOfTime);
+        destination.accept(Write.add(key, value, record));
+        atomicOp.select(key, record, aheadOfTime);
+    }
+
+    @Test(expected = AtomicStateException.class)
+    public void testNoPhantomReadWithTimestampInTheFutureUsingVerify() {
+        long aheadOfTime = Time.now() + (long) 10e9;
+        String key = Variables.register("key", TestData.getSimpleString());
+        TObject value = Variables.register("value", TestData.getTObject());
+        long record = Variables.register("record", TestData.getLong());
+
+        AtomicOperation atomicOp = (AtomicOperation) store;
+        atomicOp.verify(key, value, record, aheadOfTime);
+        destination.accept(Write.add(key, value, record));
+        atomicOp.verify(key, value, record, aheadOfTime);
+    }
+
+    @Test(expected = AtomicStateException.class)
+    public void testNoPhantomReadWithTimestampInTheFutureUsingBrowse() {
+        long aheadOfTime = Time.now() + (long) 10e9;
+        String key = Variables.register("key", TestData.getSimpleString());
+        TObject value = Variables.register("value", TestData.getTObject());
+        long record = Variables.register("record", TestData.getLong());
+
+        AtomicOperation atomicOp = (AtomicOperation) store;
+        atomicOp.browse(key, aheadOfTime);
+        destination.accept(Write.add(key, value, record));
+        atomicOp.browse(key, aheadOfTime);
+    }
+
+    @Test(expected = AtomicStateException.class)
+    public void testNoPhantomReadWithTimestampInTheFutureUsingDoExplore() {
+        long aheadOfTime = Time.now() + (long) 10e9;
+        String key = Variables.register("key", TestData.getSimpleString());
+        TObject value = Convert.javaToThrift(50);
+        long record = Variables.register("record", TestData.getLong());
+
+        AtomicOperation atomicOp = (AtomicOperation) store;
+        atomicOp.doExplore(aheadOfTime, key, Operator.BETWEEN,
+                Convert.javaToThrift(0), Convert.javaToThrift(100));
+        destination.accept(Write.add(key, value, record));
+        atomicOp.doExplore(aheadOfTime, key, Operator.BETWEEN,
+                Convert.javaToThrift(0), Convert.javaToThrift(100));
+    }
+
     @Override
     protected void cleanup(Store store) {
         FileSystem.deleteDirectory(directory);


### PR DESCRIPTION
Historical reads by definition don't grab locks but if the timestamp was set to the future there was a possibility of a Phantom Read phenomenon.