### PR TITLE
GH-115: Changed the parameter order for 'link' and 'unlink' method

### DIFF
--- a/concourse-driver-java/src/main/java/com/cinchapi/concourse/Concourse.java
+++ b/concourse-driver-java/src/main/java/com/cinchapi/concourse/Concourse.java
@@ -2156,25 +2156,25 @@ public abstract class Concourse implements AutoCloseable {
      * {@code destinations}.
      * 
      * @param key the field name
-     * @param source the id of the record where each of the links originate
      * @param destinations a collection of ids for the records where each of the
      *            links points, respectively
+     * @param source the id of the record where each of the links originate
      * @return a {@link Map} associating the ids for each of the
      *         {@code destinations} to a boolean that indicates whether the link
      *         was successfully added
      */
-    public abstract Map<Long, Boolean> link(String key, long source,
-            Collection<Long> destinations);
+    public abstract Map<Long, Boolean> link(String key,
+            Collection<Long> destinations, long source);
 
     /**
      * Append a link from {@code key} in {@code source} to {@code destination}.
      * 
      * @param key the field name
-     * @param source the id of the record where the link originates
      * @param destination the id of the record where the link points
+     * @param source the id of the record where the link originates
      * @return {@code true} if the link is added
      */
-    public abstract boolean link(String key, long source, long destination);
+    public abstract boolean link(String key, long destination, long source);
 
     /**
      * Atomically check to see if each of the {@code records} currently contains
@@ -3028,11 +3028,11 @@ public abstract class Concourse implements AutoCloseable {
      * {@code destination}.
      * 
      * @param key the field name
-     * @param source the id of the record where the link originates
      * @param destination the id of the record where the link points
+     * @param source the id of the record where the link originates
      * @return {@code true} if the link is removed
      */
-    public abstract boolean unlink(String key, long source, long destination);
+    public abstract boolean unlink(String key, long destination, long source);
 
     /**
      * Return {@code true} if {@code value} is stored for {@code key} in
@@ -5011,18 +5011,18 @@ public abstract class Concourse implements AutoCloseable {
         }
 
         @Override
-        public Map<Long, Boolean> link(String key, long source,
-                Collection<Long> destinations) {
+        public Map<Long, Boolean> link(String key,
+                Collection<Long> destinations, long source) {
             Map<Long, Boolean> result = PrettyLinkedHashMap
                     .newPrettyLinkedHashMap("Record", "Result");
             for (long destination : destinations) {
-                result.put(destination, link(key, source, destination));
+                result.put(destination, link(key, destination, source));
             }
             return result;
         }
 
         @Override
-        public boolean link(String key, long source, long destination) {
+        public boolean link(String key, long destination, long source) {
             return add(key, Link.to(destination), source);
         }
 
@@ -6065,7 +6065,7 @@ public abstract class Concourse implements AutoCloseable {
         }
 
         @Override
-        public boolean unlink(String key, long source, long destination) {
+        public boolean unlink(String key, long destination, long source) {
             return remove(key, Link.to(destination), source);
         }
 

--- a/concourse-ete-test-core/src/main/java/com/cinchapi/concourse/server/ManagedConcourseServer.java
+++ b/concourse-ete-test-core/src/main/java/com/cinchapi/concourse/server/ManagedConcourseServer.java
@@ -1325,16 +1325,16 @@ public class ManagedConcourseServer {
         }
 
         @Override
-        public Map<Long, Boolean> link(String key, long source,
-                Collection<Long> destinations) {
+        public Map<Long, Boolean> link(String key,
+                Collection<Long> destinations, long source) {
             return invoke("link", String.class, long.class, Collection.class)
-                    .with(key, source, destinations);
+                    .with(key, destinations, source);
         }
 
         @Override
-        public boolean link(String key, long source, long destination) {
+        public boolean link(String key, long destination, long source) {
             return invoke("link", String.class, long.class, long.class).with(
-                    key, source, destination);
+                    key, destination, source);
         }
 
         @Override
@@ -1632,9 +1632,9 @@ public class ManagedConcourseServer {
         }
 
         @Override
-        public boolean unlink(String key, long source, long destination) {
+        public boolean unlink(String key, long destination, long source) {
             return invoke("unlink", String.class, long.class, long.class).with(
-                    key, source, destination);
+                    key, destination, source);
         }
 
         @Override

--- a/concourse-integration-tests/src/test/java/com/cinchapi/concourse/LinksToTest.java
+++ b/concourse-integration-tests/src/test/java/com/cinchapi/concourse/LinksToTest.java
@@ -43,14 +43,14 @@ public class LinksToTest extends ConcourseIntegrationTest {
             value = TestData.getLong();
         }
         client.add("foo", value, 1);
-        client.link("foo", 1, value);
+        client.link("foo", value, 1);
         Assert.assertTrue(client.find("foo", Operator.LINKS_TO, value).contains(1L));  
     }
     
     @Test
     public void testLinkAndNoLong(){
         long value = TestData.getLong();
-        client.link("foo", 1, value);
+        client.link("foo", value, 1);
         Assert.assertTrue(client.find("foo", Operator.LINKS_TO, value).contains(1L));
     }
 

--- a/concourse-integration-tests/src/test/java/com/cinchapi/concourse/OperatorAliasTest.java
+++ b/concourse-integration-tests/src/test/java/com/cinchapi/concourse/OperatorAliasTest.java
@@ -61,10 +61,10 @@ public class OperatorAliasTest extends ConcourseIntegrationTest {
 
     @Test
     public void testLinkToAlias() {
-        client.link("foo", 1, 2);
-        client.link("foo", 3, 2);
-        client.link("foo", 4, 2);
-        client.link("foo", 5, 2);
+        client.link("foo", 2, 1);
+        client.link("foo", 2, 3);
+        client.link("foo", 2, 4);
+        client.link("foo", 2, 5);
         Assert.assertEquals(client.find("cmd", Operator.LINKS_TO, 2),
                 client.find("cmd", Operator.EQUALS, Link.to(2)));
     }

--- a/concourse-integration-tests/src/test/java/com/cinchapi/concourse/ReferentialIntegrityTest.java
+++ b/concourse-integration-tests/src/test/java/com/cinchapi/concourse/ReferentialIntegrityTest.java
@@ -34,7 +34,7 @@ public class ReferentialIntegrityTest extends ConcourseIntegrationTest {
     
     @Test
     public void testCanAddNonCircularLinks(){
-        Assert.assertTrue(client.link("foo", 1, 2));
+        Assert.assertTrue(client.link("foo", 2, 1));
     }
 
 }


### PR DESCRIPTION
The parameters for the two 'link' methods and 'unlink' method in the class Concourse were changed from (key, source, destination) to (key, destination, source). This was done to match the parameter order of (key, value, record) for the add, set, and remove methods and thus make the parameter order more intuitive. All usages were modified to adjust for this change.