### PR TITLE
CON-471: Removed Engine#browse() method

### DIFF
--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Engine.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Engine.java
@@ -483,15 +483,6 @@ public final class Engine extends BufferedStore implements
         }
     }
 
-    /**
-     * Public interface for the {@link browse()} method.
-     * 
-     * @return Set of records
-     */
-    public Set<Long> browse() {
-        return inventory.getAll();
-    }
-
     @Override
     public Map<TObject, Set<Long>> browse(String key) {
         transportLock.readLock().lock();

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/EngineTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/EngineTest.java
@@ -200,7 +200,7 @@ public class EngineTest extends BufferedStoreTest {
         engine.remove("name", Convert.javaToThrift("xyz"), 2);
         Assert.assertTrue(engine.select(2).isEmpty()); // assert record
                                                        // presently has no data
-        Assert.assertEquals(engine.browse(), Sets.<Long> newHashSet(
+        Assert.assertEquals(engine.getAllRecords(), Sets.<Long> newHashSet(
                 new Long(1), new Long(2), new Long(3), new Long(4)));
     }
 


### PR DESCRIPTION
The browse() method in the Engine class was removed and all usages were replaced by the getAllRecords() method from the Store interface.