### PR TITLE
CON-321: Added support for local references in CCL

### DIFF
--- a/concourse-server/src/main/java/com/cinchapi/concourse/lang/Parser.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/lang/Parser.java
@@ -402,29 +402,6 @@ public final class Parser {
     }
 
     /**
-     * A helper method for {@link #toPostfixNotation(String, Multimap)} to
-     * parse tokens that are possible local references.
-     *
-     * @param tok the token to parse
-     * @return the parsed and corrected to token
-     */
-    private static String parseReferenceToken(String tok) {
-        if(tok.charAt(0) == '$') {
-            if(tok.length() > 2 && tok.charAt(1) == '$') {
-                return tok.substring(2);
-            }
-            else {
-                return tok.substring(1);
-            }
-        }
-        else if(tok.length() > 2 && tok.charAt(0) == '\\'
-                && tok.charAt(1) == '$') {
-            return tok.substring(1);
-        }
-        return tok;
-    }
-
-    /**
      * A collection of tokens that indicate the parser should pivot to expecting
      * a timestamp token.
      */

--- a/concourse-server/src/main/java/com/cinchapi/concourse/lang/Parser.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/lang/Parser.java
@@ -250,11 +250,11 @@ public final class Parser {
             }
             else if(guess == GuessState.KEY) {
                 if(tok.charAt(0) == '$') {
-                    if(tok.length() > 2 && tok.substring(0, 2).equals(("$$"))) {
+                    if(tok.length() > 2 && tok.charAt(1) == '$') {
                         tok = tok.substring(2);
                         resolvedVariableConjunction = ConjunctionSymbol.AND;
                     }
-                    else if(tok.length() > 1 && tok.substring(0, 1).equals("$")) {
+                    else {
                         tok = tok.substring(1);
                         resolvedVariableConjunction = ConjunctionSymbol.OR;
                     }
@@ -491,13 +491,16 @@ public final class Parser {
      * @return the parsed and corrected to token
      */
     private static String parseReferenceToken(String tok) {
-        if(tok.length() > 2 && tok.substring(0, 2).equals(("$$"))) {
-            return tok.substring(2);
+        if(tok.charAt(0) == '$') {
+            if(tok.length() > 2 && tok.charAt(1) == '$') {
+                return tok.substring(2);
+            }
+            else {
+                return tok.substring(1);
+            }
         }
-        else if(tok.length() > 1 && tok.substring(0, 1).equals("$")) {
-            return tok.substring(1);
-        }
-        else if(tok.length() > 2 && tok.substring(0, 2).equals("\\$")) {
+        else if(tok.length() > 2 && tok.charAt(0) == '\\'
+                && tok.charAt(1) == '$') {
             return tok.substring(1);
         }
         return tok;

--- a/concourse-server/src/test/java/com/cinchapi/concourse/lang/ParserTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/lang/ParserTest.java
@@ -658,58 +658,114 @@ public class ParserTest {
 
     @Test
     public void testParseCclLocalReferences() {
-        String ccl = "name = $name";
+        Criteria criteria = Criteria.where().key("name")
+                .operator(Operator.EQUALS).value("Lebron James")
+                .build();
+        String ccl = "$name = $name";
         Multimap<String, Object> data = LinkedHashMultimap.create();
         data.put("name", "Lebron James");
         data.put("age", 30);
         data.put("team", "Cleveland Cavaliers");
-        Queue<PostfixNotationSymbol> symbols = Parser.toPostfixNotation(ccl,
-                data);
-        Assert.assertEquals(1, symbols.size());
-        Object[] expected = {"name = Lebron James"};
-        for (int i = 0; i < 1; ++i) {
-            Assert.assertTrue(symbols.poll().toString()
-                    .equals(expected[i].toString()));
-        }
+        Assert.assertEquals(Parser.toPostfixNotation(criteria.getSymbols()),
+                Parser.toPostfixNotation(ccl, data));
     }
 
     @Test
     public void testParseCclOrLocalReferences() {
-        String ccl = "name = $name";
+        Criteria criteria = Criteria.where().key("name")
+                .operator(Operator.EQUALS).value("Lebron James").or()
+                .key("name").operator(Operator.EQUALS).value("King James")
+                .build();
+        String ccl = "$name = $name";
         Multimap<String, Object> data = LinkedHashMultimap.create();
         data.put("name", "Lebron James");
         data.put("name", "King James");
         data.put("age", 30);
         data.put("team", "Cleveland Cavaliers");
-        Queue<PostfixNotationSymbol> symbols = Parser.toPostfixNotation(ccl,
-                data);
-        Assert.assertEquals(3, symbols.size());
-        Object[] expected = {"name = Lebron James", "name = King James",
-                ConjunctionSymbol.OR};
-        for (int i = 0; i < 3; ++i) {
-            Assert.assertTrue(symbols.poll().toString()
-                    .equals(expected[i].toString()));
-        }
+        Assert.assertEquals(Parser.toPostfixNotation(criteria.getSymbols()),
+                Parser.toPostfixNotation(ccl, data));
     }
 
     @Test
     public void testParseCclAndLocalReferences() {
-        String ccl = "name = $$name";
+        Criteria criteria = Criteria.where()
+                .key("name").operator(Operator.EQUALS).value("Lebron James").and()
+                .key("name").operator(Operator.EQUALS).value("King James").and()
+                .key("name").operator(Operator.EQUALS).value("Lebron")
+                .build();
+        String ccl = "$$name = $name";
         Multimap<String, Object> data = LinkedHashMultimap.create();
         data.put("name", "Lebron James");
         data.put("name", "King James");
         data.put("name", "Lebron");
         data.put("age", 30);
         data.put("team", "Cleveland Cavaliers");
-        Queue<PostfixNotationSymbol> symbols = Parser.toPostfixNotation(ccl,
-                data);
-        Assert.assertEquals(5, symbols.size());
-        Object[] expected = {"name = Lebron James", "name = King James",
-                "name = Lebron", ConjunctionSymbol.AND, ConjunctionSymbol.AND};
-        for (int i = 0; i < 5; ++i) {
-            Assert.assertTrue(symbols.poll().toString()
-                    .equals(expected[i].toString()));
-        }
+        Assert.assertEquals(Parser.toPostfixNotation(criteria.getSymbols()),
+                Parser.toPostfixNotation(ccl, data));
+    }
+
+    @Test
+    public void testParseCclBetweenWithBothReferences() {
+        Criteria criteria = Criteria.where()
+                .key("age").operator(Operator.BETWEEN).value("30").value("35").or()
+                .key("age").operator(Operator.BETWEEN).value("28").value("35")
+                .build();
+        String ccl = "where $age bw $age $retireAge";
+        Multimap<String, Object> data = LinkedHashMultimap.create();
+        data.put("name", "Lebron James");
+        data.put("age", 30);
+        data.put("age", 28);
+        data.put("retireAge", 35);
+        data.put("team", "Cleveland Cavaliers");
+        Assert.assertEquals(Parser.toPostfixNotation(criteria.getSymbols()),
+                Parser.toPostfixNotation(ccl, data));
+    }
+
+    @Test
+    public void testParseCclBetweenWithFirstReference() {
+        Criteria criteria = Criteria.where()
+                .key("age").operator(Operator.BETWEEN).value("30").value("100").or()
+                .key("age").operator(Operator.BETWEEN).value("28").value("100")
+                .build();
+        String ccl = "where $age bw $age 100";
+        Multimap<String, Object> data = LinkedHashMultimap.create();
+        data.put("name", "Lebron James");
+        data.put("age", 30);
+        data.put("age", 28);
+        data.put("team", "Cleveland Cavaliers");
+        Assert.assertEquals(Parser.toPostfixNotation(criteria.getSymbols()),
+                Parser.toPostfixNotation(ccl, data));
+    }
+
+    @Test
+    public void testParseCclBetweenWithSecondReference() {
+        Criteria criteria = Criteria.where()
+                .key("age").operator(Operator.BETWEEN).value("5").value("30").or()
+                .key("age").operator(Operator.BETWEEN).value("5").value("28")
+                .build();
+        String ccl = "where $age bw 5 $age";
+        Multimap<String, Object> data = LinkedHashMultimap.create();
+        data.put("name", "Lebron James");
+        data.put("age", 30);
+        data.put("age", 28);
+        data.put("team", "Cleveland Cavaliers");
+        Assert.assertEquals(Parser.toPostfixNotation(criteria.getSymbols()),
+                Parser.toPostfixNotation(ccl, data));
+    }
+
+    @Test
+    public void testParseCclBetweenWithEscapedValue() {
+        Criteria criteria = Criteria.where()
+                .key("name").operator(Operator.BETWEEN).value("$name").value("Lebron James")
+                .build();
+        String ccl = "where $name bw \\$name $name";
+        Multimap<String, Object> data = LinkedHashMultimap.create();
+        data.put("name", "Lebron James");
+        data.put("age", 30);
+        data.put("age", 28);
+        data.put("team", "Cleveland Cavaliers");
+        Assert.assertEquals(Parser.toPostfixNotation(criteria.getSymbols()),
+                Parser.toPostfixNotation(ccl, data));
     }
 
     @Test


### PR DESCRIPTION
In the class Parser, local reference support into a Multimap from a CCL string was added within the toPostfixNotation() method. This is needed to allow users to insert data and reference a blob of JSON data. For example insert(blob, "ipeds_id = $ipeds_id") would replace $ipeds_id by values within the blob that match ipeds_id
Unit tests were added to verify the functionality of this new update toPostfixNotation method.