### PR TITLE
Created DatasetEntry class for encapsulating entries for the Dataset

### DIFF
--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/Dataset.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/Dataset.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import com.cinchapi.concourse.plugin.data.entry.DatasetEntry;
 import com.cinchapi.concourse.server.plugin.io.PluginSerializable;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/Dataset.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/Dataset.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import com.cinchapi.concourse.plugin.data.entry.DatasetEntry;
 import com.cinchapi.concourse.server.plugin.io.PluginSerializable;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
@@ -41,8 +42,8 @@ import com.google.common.collect.Sets;
  * @author Jeff Nelson
  */
 @NotThreadSafe
-public abstract class Dataset<E, A, V> extends AbstractMap<E, Map<A, Set<V>>> implements
-        PluginSerializable {
+public abstract class Dataset<E, A, V> extends AbstractMap<E, Map<A, Set<V>>>
+        implements PluginSerializable {
 
     private static final long serialVersionUID = 7367380464340786513L;
 
@@ -130,9 +131,9 @@ public abstract class Dataset<E, A, V> extends AbstractMap<E, Map<A, Set<V>>> im
         }
         else {
             Set<V> values = Sets.newLinkedHashSet();
-            Map<V, Set<E>> index = MoreObjects
-                    .firstNonNull(inverted.get(attribute),
-                            Collections.<V, Set<E>> emptyMap());
+            Map<V, Set<E>> index = MoreObjects.firstNonNull(
+                    inverted.get(attribute),
+                    Collections.<V, Set<E>> emptyMap());
             for (Entry<V, Set<E>> entry : index.entrySet()) {
                 Set<E> entities = entry.getValue();
                 if(entities.contains(entity)) {
@@ -220,6 +221,33 @@ public abstract class Dataset<E, A, V> extends AbstractMap<E, Map<A, Set<V>>> im
         else {
             return false;
         }
+    }
+
+    /**
+     * Inserts a {@link DatasetEntry} to the {@link Dataset}
+     * 
+     * @param entry
+     * @return {@code true} if the association can be added because it didn't
+     *         previously exist
+     */
+    public boolean insert(DatasetEntry<E, A, V> entry) {
+        return insert(entry.entity(), entry.attribute(), entry.value());
+    }
+
+    /**
+     * Inserts a {@link Set<DatasetEntry>} to the {@link Dataset}
+     * 
+     * @param entry
+     * @return {@code true} if the association can be added because it didn't
+     *         previously exist
+     */
+    public boolean insert(Set<DatasetEntry<E, A, V>> entries) {
+        for (DatasetEntry<E, A, V> entry : entries) {
+            if(!insert(entry)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/Dataset.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/Dataset.java
@@ -223,9 +223,10 @@ public abstract class Dataset<E, A, V> extends AbstractMap<E, Map<A, Set<V>>>
     }
 
     /**
-     * Inserts a {@link DatasetEntry} to the {@link Dataset}
+     * Inserts a {@link DatasetEntry} to the {@link Dataset}, if it does not
+     * exist yet.
      * 
-     * @param entry
+     * @param entry the {@link Set<DatasetEntry>} to insert
      * @return {@code true} if the association can be added because it didn't
      *         previously exist
      */
@@ -234,19 +235,23 @@ public abstract class Dataset<E, A, V> extends AbstractMap<E, Map<A, Set<V>>>
     }
 
     /**
-     * Inserts a {@link Set<DatasetEntry>} to the {@link Dataset}
+     * Inserts a {@code Set<DatasetEntry>} to the {@link Dataset}. If an entry
+     * in the {@code Set} already exists within the {@link Dataset}, it is not
+     * added.
      * 
-     * @param entry
-     * @return {@code true} if the association can be added because it didn't
-     *         previously exist
+     * @param entries the {@code Set<DatasetEntry>} to insert
+     * @return the number of entries actually added into the {@link Dataset}
+     *         (this will be the size of the {@code Set} if no duplicates were
+     *         added)
      */
-    public boolean insert(Set<DatasetEntry<E, A, V>> entries) {
+    public int insert(Set<DatasetEntry<E, A, V>> entries) {
+        int count = 0;
         for (DatasetEntry<E, A, V> entry : entries) {
-            if(!insert(entry)) {
-                return false;
+            if(insert(entry)) {
+                count++;
             }
         }
-        return true;
+        return count;
     }
 
     /**

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/DatasetEntry.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/DatasetEntry.java
@@ -1,25 +1,50 @@
 package com.cinchapi.concourse.plugin.data;
 
+/**
+ * Container for objects to add into the {@link Dataset}.
+ *
+ * @param <E> the entity, typically a record in the form of a {@code Long}
+ * @param <A> the attribute, typically a key in the form of a {@code String}
+ * @param <V> the value, typically in the form of an {@code Object}
+ */
 public class DatasetEntry<E, A, V> {
     
+    /**
+     * Private instance variables
+     */
     private E entity;
     private A attribute;
     private V value;
     
+    /**
+     * Constructs an instance of the entry.
+     * @param entity the record for the entry
+     * @param attribute the key for the entry
+     * @param value the value for the entry
+     */
     public DatasetEntry(E entity, A attribute, V value) {
         this.entity = entity;
         this.attribute = attribute;
         this.value = value;
     }
     
+    /**
+     * Returns the entity
+     */
     public E entity() {
         return entity;
     }
     
+    /**
+     * Returns the attribute
+     */
     public A attribute() {
         return attribute;
     }
     
+    /**
+     * Returns the value
+     */
     public V value() {
         return value;
     }

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/DatasetEntry.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/DatasetEntry.java
@@ -48,5 +48,10 @@ public class DatasetEntry<E, A, V> {
     public V value() {
         return value;
     }
+    
+    @Override
+    public String toString() {
+        return String.format("(%s, %s, %s)", entity, attribute, value);
+    }
 
 }

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/DatasetEntry.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/DatasetEntry.java
@@ -1,4 +1,4 @@
-package com.cinchapi.concourse.plugin.data.entry;
+package com.cinchapi.concourse.plugin.data;
 
 public class DatasetEntry<E, A, V> {
     

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/entry/DatasetEntry.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/entry/DatasetEntry.java
@@ -1,0 +1,27 @@
+package com.cinchapi.concourse.plugin.data.entry;
+
+public class DatasetEntry<E, A, V> {
+    
+    private E entity;
+    private A attribute;
+    private V value;
+    
+    public DatasetEntry(E entity, A attribute, V value) {
+        this.entity = entity;
+        this.attribute = attribute;
+        this.value = value;
+    }
+    
+    public E entity() {
+        return entity;
+    }
+    
+    public A attribute() {
+        return attribute;
+    }
+    
+    public V value() {
+        return value;
+    }
+
+}

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
@@ -142,5 +142,20 @@ public class DatasetTest extends ConcourseBaseTest {
         }
         Assert.assertEquals(expected, dataset.invert());
     }
+    
+    @Test
+    public void testDuplicateInsertEntry() {
+        String key = "key";
+        Long record = 0L;
+        Boolean value = true;
+        
+        DatasetEntry<Long, String, Object> entry = new DatasetEntry<Long, String, Object>(record, key, value);
+        DatasetEntry<Long, String, Object> duplicate = new DatasetEntry<Long, String, Object>(record, key, value);
+        
+        dataset.insert(entry);
+        dataset.insert(duplicate);
+        
+        Assert.assertEquals(1, dataset.invert().size());
+    }
 
 }

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
@@ -216,7 +216,7 @@ public class DatasetTest extends ConcourseBaseTest {
     public void testDuplicateInsertSetEntry() {
         dataset.insert(0L, "occupation", "software engineer");
         dataset.insert(4L, "alive", true);
-        
+
         Set<DatasetEntry<Long, String, Object>> entries = Sets.newHashSet();
 
         entries.add(new DatasetEntry<>(0L, "occupation", "software engineer")); // duplicate
@@ -227,45 +227,53 @@ public class DatasetTest extends ConcourseBaseTest {
         entries.add(new DatasetEntry<>(5L, "age", 27));
         entries.add(new DatasetEntry<>(6L, "education", "bachelor's"));
         entries.add(new DatasetEntry<>(7L, "has_pets", false));
-        
+
         Assert.assertEquals(6, dataset.insert(entries));
     }
-    
+
     @Test
     public void testDuplicateInsertSetEntryRandom() {
-        List<DatasetEntry<Long, String, Object>> possibleEntries = Lists.newArrayList();
+        List<DatasetEntry<Long, String, Object>> possibleEntries = Lists
+                .newArrayList();
         int count = Random.getScaleCount();
-        
-        for(int i = 0; i < count; i++) {
-            possibleEntries.add(new DatasetEntry<>(Random.getLong(), Random.getSimpleString(), Random.getObject()));
+
+        for (int i = 0; i < count; i++) {
+            possibleEntries.add(new DatasetEntry<>(Random.getLong(),
+                    Random.getSimpleString(), Random.getObject()));
         }
-        
-        int subcount = (int) (count/5);
-        
+
+        int subcount = (int) (count / 5);
+
         java.util.Random r = new java.util.Random();
-        
-        Set<DatasetEntry<Long, String, Object>> preinsertedEntries = Sets.newHashSet();
-        
-        for(int i = 0; i < subcount; i++) {
-            DatasetEntry<Long, String, Object> entry = possibleEntries.get(r.nextInt(count));
+
+        Set<DatasetEntry<Long, String, Object>> preinsertedEntries = Sets
+                .newHashSet();
+
+        for (int i = 0; i < subcount; i++) {
+            DatasetEntry<Long, String, Object> entry = possibleEntries
+                    .get(r.nextInt(count));
             preinsertedEntries.add(entry);
             dataset.insert(entry);
         }
-                
-        Set<DatasetEntry<Long, String, Object>> postinsertedEntries = Sets.newHashSet();
-        
-        for(int i = 0; i < subcount; i++) {
-            DatasetEntry<Long, String, Object> entry = possibleEntries.get(r.nextInt(count));
+
+        Set<DatasetEntry<Long, String, Object>> postinsertedEntries = Sets
+                .newHashSet();
+
+        for (int i = 0; i < subcount; i++) {
+            DatasetEntry<Long, String, Object> entry = possibleEntries
+                    .get(r.nextInt(count));
             postinsertedEntries.add(entry);
         }
-        
-        Set<DatasetEntry<Long, String, Object>> commonEntries = Sets.newHashSet(preinsertedEntries);
+
+        Set<DatasetEntry<Long, String, Object>> commonEntries = Sets
+                .newHashSet(preinsertedEntries);
         commonEntries.retainAll(postinsertedEntries);
-                
+
         int numberUncommon = postinsertedEntries.size() - commonEntries.size();
-                        
-        Assert.assertEquals(numberUncommon, dataset.insert(postinsertedEntries));
-        
+
+        Assert.assertEquals(numberUncommon,
+                dataset.insert(postinsertedEntries));
+
     }
 
 }

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
@@ -17,6 +17,7 @@ package com.cinchapi.concourse.plugin.data;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,6 +26,8 @@ import org.junit.Test;
 
 import com.cinchapi.concourse.test.ConcourseBaseTest;
 import com.cinchapi.concourse.util.Random;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * <p>
@@ -117,7 +120,7 @@ public class DatasetTest extends ConcourseBaseTest {
         }
         Assert.assertEquals(inverted, dataset.invert());
     }
-    
+
     @Test
     public void testInsertEntry() {
         Map<String, Map<Object, Set<Long>>> expected = new HashMap<String, Map<Object, Set<Long>>>();
@@ -137,39 +140,132 @@ public class DatasetTest extends ConcourseBaseTest {
             subvalue.add(element);
             value.put(subkey, subvalue);
             expected.put(key, value);
-            DatasetEntry<Long, String, Object> entry = new DatasetEntry<Long, String, Object>(element, key, subkey);
+            DatasetEntry<Long, String, Object> entry = new DatasetEntry<Long, String, Object>(
+                    element, key, subkey);
             dataset.insert(entry);
         }
         Assert.assertEquals(expected, dataset.invert());
     }
-    
+
     @Test
     public void testDuplicateInsertEntry() {
         String key1 = "key1";
         Long record1 = 0L;
         Boolean value1 = true;
-        
+
         String key2 = "key2";
         Long record2 = 1L;
         Boolean value2 = false;
-        
-        DatasetEntry<Long, String, Object> entry1 = new DatasetEntry<Long, String, Object>(record1, key1, value1);
-        DatasetEntry<Long, String, Object> duplicate1 = new DatasetEntry<Long, String, Object>(record1, key1, value1);
-        
-        DatasetEntry<Long, String, Object> entry2 = new DatasetEntry<Long, String, Object>(record2, key2, value2);
-        DatasetEntry<Long, String, Object> duplicate2 = new DatasetEntry<Long, String, Object>(record2, key2, value2);
-        
+
+        DatasetEntry<Long, String, Object> entry1 = new DatasetEntry<Long, String, Object>(
+                record1, key1, value1);
+        DatasetEntry<Long, String, Object> duplicate1 = new DatasetEntry<Long, String, Object>(
+                record1, key1, value1);
+
+        DatasetEntry<Long, String, Object> entry2 = new DatasetEntry<Long, String, Object>(
+                record2, key2, value2);
+        DatasetEntry<Long, String, Object> duplicate2 = new DatasetEntry<Long, String, Object>(
+                record2, key2, value2);
+
         dataset.insert(entry1);
         dataset.insert(duplicate1);
         dataset.insert(entry2);
         dataset.insert(duplicate2);
-        
+
         Dataset<Long, String, Object> expected = new ResultDataset();
-        
-        expected.insert(0L, "key1", true);      // entry1
-        expected.insert(1L, "key2", false);     // entry2
-        
+
+        expected.insert(0L, "key1", true); // entry1
+        expected.insert(1L, "key2", false); // entry2
+
         Assert.assertEquals(expected.invert(), dataset.invert());
+    }
+
+    @Test
+    public void testInsertSetEntry() {
+        Map<String, Map<Object, Set<Long>>> expected = new HashMap<String, Map<Object, Set<Long>>>();
+        int outerCount = Random.getScaleCount();
+        int innerCount = Random.getScaleCount();
+        for (int i = 0; i < outerCount; i++) {
+            Set<DatasetEntry<Long, String, Object>> entries = Sets.newHashSet();
+            for (int j = 0; j < innerCount; j++) {
+                String key = Random.getString();
+                Map<Object, Set<Long>> value = expected.get(key);
+                if(value == null) {
+                    value = new HashMap<Object, Set<Long>>();
+                }
+                Object subkey = Random.getObject();
+                Set<Long> subvalue = value.get(subkey);
+                if(subvalue == null) {
+                    subvalue = new HashSet<Long>();
+                }
+                Long element = Random.getLong();
+                subvalue.add(element);
+                value.put(subkey, subvalue);
+                expected.put(key, value);
+                DatasetEntry<Long, String, Object> entry = new DatasetEntry<Long, String, Object>(
+                        element, key, subkey);
+                entries.add(entry);
+            }
+            dataset.insert(entries);
+        }
+
+        Assert.assertEquals(expected, dataset.invert());
+    }
+
+    @Test
+    public void testDuplicateInsertSetEntry() {
+        dataset.insert(0L, "occupation", "software engineer");
+        dataset.insert(4L, "alive", true);
+        
+        Set<DatasetEntry<Long, String, Object>> entries = Sets.newHashSet();
+
+        entries.add(new DatasetEntry<>(0L, "occupation", "software engineer")); // duplicate
+        entries.add(new DatasetEntry<>(1L, "first_name", "Foo"));
+        entries.add(new DatasetEntry<>(2L, "last_name", "Bar"));
+        entries.add(new DatasetEntry<>(3L, "email", "foo@bar.com"));
+        entries.add(new DatasetEntry<>(4L, "alive", true)); // duplicate
+        entries.add(new DatasetEntry<>(5L, "age", 27));
+        entries.add(new DatasetEntry<>(6L, "education", "bachelor's"));
+        entries.add(new DatasetEntry<>(7L, "has_pets", false));
+        
+        Assert.assertEquals(6, dataset.insert(entries));
+    }
+    
+    @Test
+    public void testDuplicateInsertSetEntryRandom() {
+        List<DatasetEntry<Long, String, Object>> possibleEntries = Lists.newArrayList();
+        int count = Random.getScaleCount();
+        
+        for(int i = 0; i < count; i++) {
+            possibleEntries.add(new DatasetEntry<>(Random.getLong(), Random.getSimpleString(), Random.getObject()));
+        }
+        
+        int subcount = (int) (count/5);
+        
+        java.util.Random r = new java.util.Random();
+        
+        Set<DatasetEntry<Long, String, Object>> preinsertedEntries = Sets.newHashSet();
+        
+        for(int i = 0; i < subcount; i++) {
+            DatasetEntry<Long, String, Object> entry = possibleEntries.get(r.nextInt(count));
+            preinsertedEntries.add(entry);
+            dataset.insert(entry);
+        }
+                
+        Set<DatasetEntry<Long, String, Object>> postinsertedEntries = Sets.newHashSet();
+        
+        for(int i = 0; i < subcount; i++) {
+            DatasetEntry<Long, String, Object> entry = possibleEntries.get(r.nextInt(count));
+            postinsertedEntries.add(entry);
+        }
+        
+        Set<DatasetEntry<Long, String, Object>> commonEntries = Sets.newHashSet(preinsertedEntries);
+        commonEntries.retainAll(postinsertedEntries);
+                
+        int numberUncommon = postinsertedEntries.size() - commonEntries.size();
+                        
+        Assert.assertEquals(numberUncommon, dataset.insert(postinsertedEntries));
+        
     }
 
 }

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
@@ -20,12 +20,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import com.cinchapi.concourse.plugin.data.entry.DatasetEntry;
 import com.cinchapi.concourse.test.ConcourseBaseTest;
 import com.cinchapi.concourse.util.Random;
-
-import org.junit.Assert;
 
 /**
  * <p>
@@ -117,6 +117,31 @@ public class DatasetTest extends ConcourseBaseTest {
             dataset.put(loong, originalSubmap);
         }
         Assert.assertEquals(inverted, dataset.invert());
+    }
+    
+    @Test
+    public void testInsertEntry() {
+        Map<String, Map<Object, Set<Long>>> expected = new HashMap<String, Map<Object, Set<Long>>>();
+        int count = Random.getScaleCount();
+        for (int i = 0; i < count; i++) {
+            String key = Random.getString();
+            Map<Object, Set<Long>> value = expected.get(key);
+            if(value == null) {
+                value = new HashMap<Object, Set<Long>>();
+            }
+            Object subkey = Random.getObject();
+            Set<Long> subvalue = value.get(subkey);
+            if(subvalue == null) {
+                subvalue = new HashSet<Long>();
+            }
+            Long element = Random.getLong();
+            subvalue.add(element);
+            value.put(subkey, subvalue);
+            expected.put(key, value);
+            DatasetEntry<Long, String, Object> entry = new DatasetEntry<Long, String, Object>(element, key, subkey);
+            dataset.insert(entry);
+        }
+        Assert.assertEquals(expected, dataset.invert());
     }
 
 }

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.cinchapi.concourse.plugin.data.entry.DatasetEntry;
 import com.cinchapi.concourse.test.ConcourseBaseTest;
 import com.cinchapi.concourse.util.Random;
 

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
@@ -145,17 +145,31 @@ public class DatasetTest extends ConcourseBaseTest {
     
     @Test
     public void testDuplicateInsertEntry() {
-        String key = "key";
-        Long record = 0L;
-        Boolean value = true;
+        String key1 = "key1";
+        Long record1 = 0L;
+        Boolean value1 = true;
         
-        DatasetEntry<Long, String, Object> entry = new DatasetEntry<Long, String, Object>(record, key, value);
-        DatasetEntry<Long, String, Object> duplicate = new DatasetEntry<Long, String, Object>(record, key, value);
+        String key2 = "key2";
+        Long record2 = 1L;
+        Boolean value2 = false;
         
-        dataset.insert(entry);
-        dataset.insert(duplicate);
+        DatasetEntry<Long, String, Object> entry1 = new DatasetEntry<Long, String, Object>(record1, key1, value1);
+        DatasetEntry<Long, String, Object> duplicate1 = new DatasetEntry<Long, String, Object>(record1, key1, value1);
         
-        Assert.assertEquals(1, dataset.invert().size());
+        DatasetEntry<Long, String, Object> entry2 = new DatasetEntry<Long, String, Object>(record2, key2, value2);
+        DatasetEntry<Long, String, Object> duplicate2 = new DatasetEntry<Long, String, Object>(record2, key2, value2);
+        
+        dataset.insert(entry1);
+        dataset.insert(duplicate1);
+        dataset.insert(entry2);
+        dataset.insert(duplicate2);
+        
+        Dataset<Long, String, Object> expected = new ResultDataset();
+        
+        expected.insert(0L, "key1", true);      // entry1
+        expected.insert(1L, "key2", false);     // entry2
+        
+        Assert.assertEquals(expected.invert(), dataset.invert());
     }
 
 }


### PR DESCRIPTION
In order for parts of the key-derivation to be detached from the process of updating the `Dataset`, I created a container that is instantiated by these parts and then passed back to the main `ImpromptuApplication` which takes care of entering them into the `Dataset`. Unit Tests are included.