### PR TITLE
[CON-496]  Concourse / Task CON-496 Return Dataset from ConcourseServer select methods that return Map<Long, Map<String, Set<TObject>>>

### DIFF
--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/ResultDataset.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/ResultDataset.java
@@ -23,13 +23,13 @@ import java.util.Set;
  * 
  * @author Jeff Nelson
  */
-public class ResultDataset extends Dataset<Long, String, Object> {
+public class ResultDataset<E, A, V> extends Dataset<E, A, V> {
 
     private static final long serialVersionUID = 931353732079540266L;
 
 
     @Override
-    protected Map<Object, Set<Long>> createInvertedMultimap() {
+    protected Map<V, Set<E>> createInvertedMultimap() {
         return TrackingLinkedHashMultimap.create();
     }
 

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/ResultDataset.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/plugin/data/ResultDataset.java
@@ -18,18 +18,20 @@ package com.cinchapi.concourse.plugin.data;
 import java.util.Map;
 import java.util.Set;
 
+import com.cinchapi.concourse.thrift.TObject;
+
 /**
  * 
  * 
  * @author Jeff Nelson
  */
-public class ResultDataset<E, A, V> extends Dataset<E, A, V> {
+public class ResultDataset extends Dataset<Long, String, TObject> {
 
     private static final long serialVersionUID = 931353732079540266L;
 
 
     @Override
-    protected Map<V, Set<E>> createInvertedMultimap() {
+    protected Map<TObject, Set<Long>> createInvertedMultimap() {
         return TrackingLinkedHashMultimap.create();
     }
 

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/DatasetTest.java
@@ -17,7 +17,6 @@ package com.cinchapi.concourse.plugin.data;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,9 +24,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.cinchapi.concourse.test.ConcourseBaseTest;
+import com.cinchapi.concourse.thrift.TObject;
+import com.cinchapi.concourse.util.Convert;
 import com.cinchapi.concourse.util.Random;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * <p>
@@ -39,7 +38,7 @@ import com.google.common.collect.Sets;
  */
 public class DatasetTest extends ConcourseBaseTest {
 
-    private Dataset<Long, String, Object> dataset;
+    private Dataset<Long, String, TObject> dataset;
 
     @Override
     public void beforeEachTest() {
@@ -61,7 +60,7 @@ public class DatasetTest extends ConcourseBaseTest {
             if(value == null) {
                 value = new HashMap<Object, Set<Long>>();
             }
-            Object subkey = Random.getObject();
+            TObject subkey = Convert.javaToThrift(Random.getObject());
             Set<Long> subvalue = value.get(subkey);
             if(subvalue == null) {
                 subvalue = new HashSet<Long>();
@@ -77,18 +76,18 @@ public class DatasetTest extends ConcourseBaseTest {
 
     @Test
     public void testPut() {
-        Map<String, Map<Object, Set<Long>>> inverted = new HashMap<String, Map<Object, Set<Long>>>();
-        Map<Long, Map<String, Set<Object>>> original = new HashMap<Long, Map<String, Set<Object>>>();
+        Map<String, Map<TObject, Set<Long>>> inverted = new HashMap<String, Map<TObject, Set<Long>>>();
+        Map<Long, Map<String, Set<TObject>>> original = new HashMap<Long, Map<String, Set<TObject>>>();
         int count = Random.getScaleCount();
         for (int i = 0; i < count; i++) {
             String string = Random.getString();
             Long loong = Random.getLong();
-            Object object = Random.getObject();
+            TObject object = Convert.javaToThrift(Random.getObject());
 
             // EXPECTATION OF INVERTED
-            Map<Object, Set<Long>> invertedSubmap = inverted.get(string);
+            Map<TObject, Set<Long>> invertedSubmap = inverted.get(string);
             if(invertedSubmap == null) {
-                invertedSubmap = new HashMap<Object, Set<Long>>();
+                invertedSubmap = new HashMap<TObject, Set<Long>>();
             }
 
             Set<Long> invertedSubset = invertedSubmap.get(object);
@@ -101,14 +100,14 @@ public class DatasetTest extends ConcourseBaseTest {
             inverted.put(string, invertedSubmap);
 
             // EXPECTATION OF ORIGINAL
-            Map<String, Set<Object>> originalSubmap = original.get(loong);
+            Map<String, Set<TObject>> originalSubmap = original.get(loong);
             if(originalSubmap == null) {
-                originalSubmap = new HashMap<String, Set<Object>>();
+                originalSubmap = new HashMap<String, Set<TObject>>();
             }
 
-            Set<Object> originalSubset = originalSubmap.get(string);
+            Set<TObject> originalSubset = originalSubmap.get(string);
             if(originalSubset == null) {
-                originalSubset = new HashSet<Object>();
+                originalSubset = new HashSet<TObject>();
             }
 
             originalSubset.add(object);

--- a/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/TrackingMultimapDataTypeTest.java
+++ b/concourse-plugin-core/src/test/java/com/cinchapi/concourse/plugin/data/TrackingMultimapDataTypeTest.java
@@ -31,7 +31,7 @@ import com.cinchapi.concourse.util.Random;
  */
 public class TrackingMultimapDataTypeTest {
     
-private TrackingMultimap<Object, Long> map;
+    private TrackingMultimap<Object, Long> map;
     
     @Before
     public void beforeEachTest() {

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
@@ -53,6 +53,7 @@ import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportException;
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 
+import com.cinchapi.common.reflect.Reflection;
 import com.cinchapi.concourse.Constants;
 import com.cinchapi.concourse.Link;
 import com.cinchapi.concourse.Timestamp;
@@ -69,6 +70,7 @@ import com.cinchapi.concourse.lang.NaturalLanguage;
 import com.cinchapi.concourse.lang.Parser;
 import com.cinchapi.concourse.lang.PostfixNotationSymbol;
 import com.cinchapi.concourse.lang.Symbol;
+import com.cinchapi.concourse.plugin.data.ResultDataset;
 import com.cinchapi.concourse.security.AccessManager;
 import com.cinchapi.concourse.server.http.HttpServer;
 import com.cinchapi.concourse.server.io.FileSystem;
@@ -138,6 +140,11 @@ import static com.cinchapi.concourse.server.GlobalState.*;
  * @author Jeff Nelson
  */
 public class ConcourseServer implements ConcourseService.Iface, ConcourseServerMXBean {
+    
+    /**
+     * The class representation of {@link RemoteInvocationThread}.
+     */
+    private static final Class<?> INVOCATION_THREAD_CLASS = Reflection.getClassCasted("com.cinchapi.concourse.server.plugin.RemoteInvocationThread");
 
     /**
      * Create a new {@link ConcourseServer} instance that uses the default port
@@ -3114,8 +3121,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = Maps
-                    .newLinkedHashMap();
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                    .isAssignableFrom(Thread.currentThread().getClass()))
+                            ? new ResultDataset<Long, String, TObject>()
+                            : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
                 atomic = store.startAtomicOperation();
@@ -3154,8 +3163,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = Maps
-                    .newLinkedHashMap();
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                    .isAssignableFrom(Thread.currentThread().getClass()))
+                            ? new ResultDataset<Long, String, TObject>()
+                            : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
                 atomic = store.startAtomicOperation();
@@ -3204,7 +3215,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = Maps.newLinkedHashMap();
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
             atomic = store.startAtomicOperation();
@@ -3238,7 +3252,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = Maps.newLinkedHashMap();
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
             atomic = store.startAtomicOperation();
@@ -3514,8 +3531,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = Maps
-                    .newLinkedHashMap();
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                    .isAssignableFrom(Thread.currentThread().getClass()))
+                            ? new ResultDataset<Long, String, TObject>()
+                            : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
                 atomic = store.startAtomicOperation();
@@ -3553,8 +3572,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = Maps
-                    .newLinkedHashMap();
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                    .isAssignableFrom(Thread.currentThread().getClass()))
+                            ? new ResultDataset<Long, String, TObject>()
+                            : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
                 atomic = store.startAtomicOperation();
@@ -3603,7 +3624,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = Maps.newLinkedHashMap();
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
             atomic = store.startAtomicOperation();
@@ -3637,7 +3661,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = Maps.newLinkedHashMap();
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
             atomic = store.startAtomicOperation();
@@ -3708,7 +3735,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             TransactionToken transaction, String environment) throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = Maps.newLinkedHashMap();
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
             atomic = store.startAtomicOperation();
@@ -3741,8 +3771,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = TMaps
-                .newLinkedHashMapWithCapacity(records.size());
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : TMaps.newLinkedHashMapWithCapacity(records.size());
         for (long record : records) {
             Map<String, Set<TObject>> entry = TMaps
                     .newLinkedHashMapWithCapacity(keys.size());
@@ -3814,7 +3846,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             TransactionToken transaction, String environment) throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = Maps.newLinkedHashMap();
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
             atomic = store.startAtomicOperation();
@@ -3839,8 +3874,10 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             TransactionToken transaction, String environment) throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = TMaps
-                .newLinkedHashMapWithCapacity(records.size());
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
+                .isAssignableFrom(Thread.currentThread().getClass()))
+                        ? new ResultDataset<Long, String, TObject>()
+                        : TMaps.newLinkedHashMapWithCapacity(records.size());
         for (long record : records) {
             result.put(record, store.select(record, timestamp));
         }

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
@@ -3116,9 +3116,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                    .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset()
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                    .currentThread().getClass()) ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3158,9 +3157,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                    .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset()
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                    .currentThread().getClass()) ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3210,9 +3208,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3247,9 +3244,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3526,9 +3522,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                    .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset()
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                    .currentThread().getClass()) ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3567,9 +3562,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         try {
             Queue<PostfixNotationSymbol> queue = Parser.toPostfixNotation(ccl);
             AtomicSupport store = getStore(transaction, environment);
-            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                    .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset()
+            Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                    .currentThread().getClass()) ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3619,9 +3613,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3656,9 +3649,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         checkAccess(creds, transaction);
         Queue<PostfixNotationSymbol> queue = convertCriteriaToQueue(criteria);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3730,9 +3722,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             TransactionToken transaction, String environment) throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3766,9 +3757,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : TMaps.newLinkedHashMapWithCapacity(records.size());
         for (long record : records) {
             Map<String, Set<TObject>> entry = TMaps
@@ -3841,9 +3831,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             TransactionToken transaction, String environment) throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3869,9 +3858,8 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             TransactionToken transaction, String environment) throws TException {
         checkAccess(creds, transaction);
         AtomicSupport store = getStore(transaction, environment);
-        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
-                .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset()
+        Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS == Thread
+                .currentThread().getClass()) ? new ResultDataset()
                         : TMaps.newLinkedHashMapWithCapacity(records.size());
         for (long record : records) {
             result.put(record, store.select(record, timestamp));

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
@@ -142,11 +142,6 @@ import static com.cinchapi.concourse.server.GlobalState.*;
 public class ConcourseServer implements ConcourseService.Iface, ConcourseServerMXBean {
     
     /**
-     * The class representation of {@link RemoteInvocationThread}.
-     */
-    private static final Class<?> INVOCATION_THREAD_CLASS = Reflection.getClassCasted("com.cinchapi.concourse.server.plugin.RemoteInvocationThread");
-
-    /**
      * Create a new {@link ConcourseServer} instance that uses the default port
      * and storage locations or those defined in the accessible
      * {@code concourse.prefs} file.
@@ -3123,7 +3118,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             AtomicSupport store = getStore(transaction, environment);
             Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                     .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset<Long, String, TObject>()
+                            ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3165,7 +3160,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             AtomicSupport store = getStore(transaction, environment);
             Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                     .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset<Long, String, TObject>()
+                            ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3217,7 +3212,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3254,7 +3249,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3533,7 +3528,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             AtomicSupport store = getStore(transaction, environment);
             Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                     .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset<Long, String, TObject>()
+                            ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3574,7 +3569,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
             AtomicSupport store = getStore(transaction, environment);
             Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                     .isAssignableFrom(Thread.currentThread().getClass()))
-                            ? new ResultDataset<Long, String, TObject>()
+                            ? new ResultDataset()
                             : Maps.newLinkedHashMap();
             AtomicOperation atomic = null;
             while (atomic == null || !atomic.commit()) {
@@ -3626,7 +3621,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3663,7 +3658,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3737,7 +3732,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3773,7 +3768,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : TMaps.newLinkedHashMapWithCapacity(records.size());
         for (long record : records) {
             Map<String, Set<TObject>> entry = TMaps
@@ -3848,7 +3843,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : Maps.newLinkedHashMap();
         AtomicOperation atomic = null;
         while (atomic == null || !atomic.commit()) {
@@ -3876,7 +3871,7 @@ public class ConcourseServer implements ConcourseService.Iface, ConcourseServerM
         AtomicSupport store = getStore(transaction, environment);
         Map<Long, Map<String, Set<TObject>>> result = (INVOCATION_THREAD_CLASS
                 .isAssignableFrom(Thread.currentThread().getClass()))
-                        ? new ResultDataset<Long, String, TObject>()
+                        ? new ResultDataset()
                         : TMaps.newLinkedHashMapWithCapacity(records.size());
         for (long record : records) {
             result.put(record, store.select(record, timestamp));

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/GlobalState.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/GlobalState.java
@@ -24,6 +24,7 @@ import java.util.concurrent.LinkedTransferQueue;
 
 import javax.annotation.Nullable;
 
+import com.cinchapi.common.reflect.Reflection;
 import com.cinchapi.concourse.Constants;
 import com.cinchapi.concourse.annotate.NonPreference;
 import com.cinchapi.concourse.config.ConcourseServerPreferences;
@@ -207,6 +208,13 @@ public final class GlobalState extends Constants {
      * </p>
      */
     public static Level LOG_LEVEL = Level.INFO;
+    
+    /**
+     * The class representation of {@link RemoteInvocationThread}.
+     */
+    @NonPreference
+    public static final Class<?> INVOCATION_THREAD_CLASS = Reflection.getClassCasted("com.cinchapi.concourse.server.plugin.RemoteInvocationThread");
+
 
     /**
      * Whether log messages should also be printed to the console.


### PR DESCRIPTION
I changed the `ResultDataset` class to be type parameterized. This is because, by default, `ResultDataset` extended `Dataset<Long, String, Object>`, which made it incompatible to cast to a `Map<Long, Map<String, Set<TObject>>>`. By type parameterizing, this can be specified. If I were to explicitly specify that `ResultDataset` extended `Dataset<Long, String, TObject>`, the problem would be solved for `ConcourseServer` but there would then be incompatibilities with unit testing for the visualization engine and impromptu which use Objects instead of TObjects. This solution therefore maintains backwards compatibility.

Since `RemoteInvocationThread` is a package-friendly class, I was unable to call `instanceof` and instead used `Reflection.getCastedClass(String className)` to get the `Class<?>`, which I then used to determine if the `Thread.currentThread()` was assignable from it. The benefit of this approach is that there is no need to increase the visibility of `RemoteInvocationThread`, but it does create a hidden dependency due to the explicit package name specification in the `Reflection` call. Another solution would be to link the `Reflection` call to another related class in the same package as `RemoteInvocationThread`, such that in the event that one moves to another package, the other might as well and does not disrupt the call. Alternatively, we could just increase the visibility of `RemoteInvocationThread` to `public`, allowing the use of `instanceof`.