### PR TITLE
[CON-133] Implementation of verify with operator parameter

### DIFF
--- a/concourse-driver-java/src/main/java/com/cinchapi/concourse/Concourse.java
+++ b/concourse-driver-java/src/main/java/com/cinchapi/concourse/Concourse.java
@@ -3091,6 +3091,80 @@ public abstract class Concourse implements AutoCloseable {
             Timestamp timestamp);
 
     /**
+     * Return {@code true} if a value that satisfies {@code operator} in relation to {@code value}
+     * is stored for {@code key} in {@code record}.
+     *
+     * @param key the field name
+     * @param operator the operator to use
+     * @param value the value to use
+     * @param record the record id
+     * @return {@code true} if a satisfying value is stored in the field, otherwise
+     *         {@code false}
+     */
+    public abstract boolean verify(String key, Operator operator, Object value,
+            long record);
+
+    /**
+     * Return {@code true} if a value that satisfies {@code operator} in relation to {@code value}
+     * is stored for {@code key} in {@code record} at {@code timestamp}.
+     *
+     * @param key the field name
+     * @param operator the operator to use
+     * @param value the value to use
+     * @param record the record id
+     * @param timestamp a {@link Timestamp} that represents the historical
+     *            instant to use in the lookup – created from either a
+     *            {@link Timestamp#fromString(String) natural language
+     *            description} of a point in time (i.e. two weeks ago), OR
+     *            the {@link Timestamp#fromMicros(long) number
+     *            of microseconds} since the Unix epoch, OR
+     *            a {@link Timestamp#fromJoda(org.joda.time.DateTime) Joda
+     *            DateTime} object
+     * @return {@code true} if a satisfying value is stored in the field, otherwise
+     *         {@code false}
+     */
+    public abstract boolean verify(String key, Operator operator, Object value,
+            long record, Timestamp timestamp);
+
+    /**
+     * Return {@code true} if a value that satisfies {@code operator} in relation to {@code value}
+     * and {@code value2} is stored for {@code key} in {@code record}.
+     *
+     * @param key the field name
+     * @param operator the operator to use
+     * @param value the first value to use (left side of operator)
+     * @param value2 the second value to use (right side of operator)
+     * @param record the record id
+     * @return {@code true} if a satisfying value is stored in the field, otherwise
+     *         {@code false}
+     */
+    public abstract boolean verify(String key, Operator operator, Object value,
+            Object value2, long record);
+
+    /**
+     * Return {@code true} if a value that satisfies {@code operator} in relation to {@code value}
+     * and {@code value2} is stored for {@code key} in {@code record} at {@code timestamp}.
+     *
+     * @param key the field name
+     * @param operator the operator to use
+     * @param value the first value to use
+     * @param value2 the second value to use
+     * @param record the record id
+     * @param timestamp a {@link Timestamp} that represents the historical
+     *            instant to use in the lookup – created from either a
+     *            {@link Timestamp#fromString(String) natural language
+     *            description} of a point in time (i.e. two weeks ago), OR
+     *            the {@link Timestamp#fromMicros(long) number
+     *            of microseconds} since the Unix epoch, OR
+     *            a {@link Timestamp#fromJoda(org.joda.time.DateTime) Joda
+     *            DateTime} object
+     * @return {@code true} if a satisfying value is stored in the field, otherwise
+     *         {@code false}
+     */
+    public abstract boolean verify(String key, Operator operator, Object value,
+            Object value2, long record, Timestamp timestamp);
+
+    /**
      * Atomically replace {@code expected} with {@code replacement} for
      * {@code key} in {@code record} if and only if {@code expected} is
      * currently stored in the field.
@@ -6144,6 +6218,84 @@ public abstract class Concourse implements AutoCloseable {
                         return client.verifyKeyValueRecordTime(key,
                                 Convert.javaToThrift(value), record,
                                 timestamp.getMicros(), creds, transaction,
+                                environment);
+                    }
+                }
+
+            });
+        }
+
+        @Override
+        public boolean verify(final String key, final Operator operator,
+                final Object value, final long record) {
+            return execute(new Callable<Boolean>() {
+
+                @Override
+                public Boolean call() throws Exception {
+                        return client.verifyKeyOperatorValueRecord(key,
+                                operator, Convert.javaToThrift(value), record, creds,
+                                transaction, environment);
+
+                }
+            });
+        }
+
+        @Override
+        public boolean verify(final String key, final Operator operator,
+                final Object value, final long record, final Timestamp timestamp) {
+            return execute(new Callable<Boolean>() {
+
+                @Override
+                public Boolean call() throws Exception {
+                    if(timestamp.isString()) {
+                        return client.verifyKeyOperatorValueRecordTimestr(key,
+                                operator, Convert.javaToThrift(value), record,
+                                timestamp.toString(), creds, transaction,
+                                environment);
+                    }
+                    else {
+                        return client.verifyKeyOperatorValueRecordTime(key,
+                                operator, Convert.javaToThrift(value), record,
+                                timestamp.getMicros(), creds, transaction,
+                                environment);
+                    }
+                }
+
+            });
+        }
+
+        @Override
+        public boolean verify(final String key, final Operator operator,
+                final Object value, final Object value2, final long record) {
+            return execute(new Callable<Boolean>() {
+
+                @Override
+                public Boolean call() throws Exception {
+                    return client.verifyKeyOperatorValueValueRecord(key,
+                            operator, Convert.javaToThrift(value), Convert.javaToThrift(value2), record, creds,
+                            transaction, environment);
+
+                }
+            });
+        }
+
+        @Override
+        public boolean verify(final String key, final Operator operator,
+                final Object value, final Object value2, final long record, final Timestamp timestamp) {
+            return execute(new Callable<Boolean>() {
+
+                @Override
+                public Boolean call() throws Exception {
+                    if(timestamp.isString()) {
+                        return client.verifyKeyOperatorValueValueRecordTimestr(key,
+                                operator, Convert.javaToThrift(value), Convert.javaToThrift(value2),
+                                record, timestamp.toString(), creds, transaction,
+                                environment);
+                    }
+                    else {
+                        return client.verifyKeyOperatorValueValueRecordTime(key,
+                                operator, Convert.javaToThrift(value), Convert.javaToThrift(value2),
+                                record, timestamp.getMicros(), creds, transaction,
                                 environment);
                     }
                 }

--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/server/plugin/StatefulConcourseService.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/server/plugin/StatefulConcourseService.java
@@ -291,6 +291,24 @@ abstract class StatefulConcourseService {
 
     VALUE_TRANSFORM.put("verifyKeyValueRecordTimestr", 1);
 
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueRecord", 2);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueRecordTime", 2);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueRecordTimestr", 2);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueValueRecord", 2);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueValueRecord", 3);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueValueRecordTime", 2);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueValueRecordTime", 3);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueValueRecordTimestr", 2);
+
+    VALUE_TRANSFORM.put("verifyKeyOperatorValueValueRecordTimestr", 3);
+
     CRITERIA_TRANSFORM.put("findCriteria", 0);
 
     VALUE_TRANSFORM.put("findKeyOperatorValues", 2);
@@ -579,6 +597,18 @@ abstract class StatefulConcourseService {
     public boolean verifyKeyValueRecordTime(String key, Object value, long record, long timestamp) { throw new UnsupportedOperationException(); }
 
     public boolean verifyKeyValueRecordTimestr(String key, Object value, long record, String timestamp) { throw new UnsupportedOperationException(); }
+
+    public boolean verifyKeyOperatorValueRecord(String key, Operator operator, Object value, long record) { throw new UnsupportedOperationException(); }
+
+    public boolean verifyKeyOperatorValueRecordTime(String key, Operator operator, Object value, long record, long timestamp) { throw new UnsupportedOperationException(); }
+
+    public boolean verifyKeyOperatorValueRecordTimestr(String key, Operator operator, Object value, long record, String timestamp) { throw new UnsupportedOperationException(); }
+
+    public boolean verifyKeyOperatorValueValueRecord(String key, Operator operator, Object value, Object value2, long record) { throw new UnsupportedOperationException(); }
+
+    public boolean verifyKeyOperatorValueValueRecordTime(String key, Operator operator, Object value, Object value2, long record, long timestamp) { throw new UnsupportedOperationException(); }
+
+    public boolean verifyKeyOperatorValueValueRecordTimestr(String key, Operator operator, Object value, Object value2, long record, String timestamp) { throw new UnsupportedOperationException(); }
 
     public String jsonifyRecords(List<Long> records, boolean identifier) { throw new UnsupportedOperationException(); }
 

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
@@ -4060,6 +4060,66 @@ public class ConcourseServer implements
                 environment);
     }
 
+    @Override
+    @ThrowsThriftExceptions
+    public boolean verifyKeyOperatorValueRecord(String key, Operator operator, TObject value, long record,
+            AccessToken creds, TransactionToken transaction, String environment) throws TException {
+        checkAccess(creds, transaction);
+        return !getStore(transaction, environment).verify(key, operator, value, record).isEmpty();
+    }
+
+    @Override
+    @HistoricalRead
+    @ThrowsThriftExceptions
+    public boolean verifyKeyOperatorValueRecordTime(String key, Operator operator, TObject value,
+            long record, long timestamp, AccessToken creds,
+            TransactionToken transaction, String environment) throws TException {
+        checkAccess(creds, transaction);
+        return !getStore(transaction, environment).verify(key, operator, value, record,
+                timestamp).isEmpty();
+    }
+
+    @Override
+    @Alias
+    @ThrowsThriftExceptions
+    public boolean verifyKeyOperatorValueRecordTimestr(String key, Operator operator, TObject value,
+            long record, String timestamp, AccessToken creds,
+            TransactionToken transaction, String environment) throws TException {
+        return verifyKeyOperatorValueRecordTime(key, operator, value, record,
+                NaturalLanguage.parseMicros(timestamp), creds, transaction,
+                environment);
+    }
+
+    @Override
+    @ThrowsThriftExceptions
+    public boolean verifyKeyOperatorValueValueRecord(String key, Operator operator, TObject value, TObject value2, long record,
+                                                AccessToken creds, TransactionToken transaction, String environment) throws TException {
+        checkAccess(creds, transaction);
+        return !getStore(transaction, environment).verify(key, operator, value, value2, record).isEmpty();
+    }
+
+    @Override
+    @HistoricalRead
+    @ThrowsThriftExceptions
+    public boolean verifyKeyOperatorValueValueRecordTime(String key, Operator operator, TObject value,
+            TObject value2, long record, long timestamp, AccessToken creds,
+            TransactionToken transaction, String environment) throws TException {
+        checkAccess(creds, transaction);
+        return !getStore(transaction, environment).verify(key, operator, value, value2, record,
+                timestamp).isEmpty();
+    }
+
+    @Override
+    @Alias
+    @ThrowsThriftExceptions
+    public boolean verifyKeyOperatorValueValueRecordTimestr(String key, Operator operator, TObject value,
+            TObject value2, long record, String timestamp, AccessToken creds,
+            TransactionToken transaction, String environment) throws TException {
+        return verifyKeyOperatorValueValueRecordTime(key, operator, value, value2, record,
+                NaturalLanguage.parseMicros(timestamp), creds, transaction,
+                environment);
+    }
+
     @Atomic
     @Override
     @AutoRetry

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/AtomicOperation.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/AtomicOperation.java
@@ -456,6 +456,50 @@ public class AtomicOperation extends BufferedStore implements
         }
     }
 
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, long record)
+            throws AtomicStateException {
+        checkState();
+        Token token = Token.wrap(key, record);
+        source.addVersionChangeListener(token, this);
+        reads2Lock.add(token);
+        return super.verify(key, operator, value, record, true);
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, long record, long timestamp)
+            throws AtomicStateException {
+        if(timestamp > Time.now()) {
+            return verify(key, operator, value, record);
+        }
+        else {
+            checkState();
+            return super.verify(key, operator, value, record, timestamp);
+        }
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record)
+            throws AtomicStateException {
+        checkState();
+        Token token = Token.wrap(key, record);
+        source.addVersionChangeListener(token, this);
+        reads2Lock.add(token);
+        return super.verify(key, operator, value, value2, record, true);
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record, long timestamp)
+            throws AtomicStateException {
+        if(timestamp > Time.now()) {
+            return verify(key, operator, value, value2, record);
+        }
+        else {
+            checkState();
+            return super.verify(key, operator, value, value2, record, timestamp);
+        }
+    }
+
     /**
      * Check each one of the {@link #intentions} against the
      * {@link #destination} and grab the appropriate locks along the way. This

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/AtomicSupport.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/AtomicSupport.java
@@ -18,6 +18,7 @@ package com.cinchapi.concourse.server.storage;
 import java.util.Map;
 import java.util.Set;
 
+import com.cinchapi.concourse.server.model.Value;
 import com.cinchapi.concourse.thrift.Operator;
 import com.cinchapi.concourse.thrift.TObject;
 
@@ -155,4 +156,38 @@ public interface AtomicSupport extends PermanentStore, VersionChangeNotifier {
      */
     public boolean verifyUnsafe(String key, TObject value, long record);
 
+    /**
+     * Verify {@code key} has a satisfying value in {@code record}.
+     * This method checks that there is currently a mapping from {@code key} to
+     * a satisfying value in {@code record}.
+     * This method is ONLY appropriate to call from the methods of
+     * {@link #AtomicOperation} class because in this case intermediate read
+     * {@link #Lock} is not required.
+     *
+     * @param key
+     * @param operator
+     * @param value
+     * @param record
+     * @return A set of values associated with {@code key} in {@code record} that are satisfying.
+     *         Empty if no satisfying value exists.
+     */
+    public Set<Value> verifyUnsafe(String key, Operator operator, TObject value, long record);
+
+    /**
+     * Verify {@code key} has a satisfying value in {@code record}.
+     * This method checks that there is currently a mapping from {@code key} to
+     * a satisfying value in {@code record}.
+     * This method is ONLY appropriate to call from the methods of
+     * {@link #AtomicOperation} class because in this case intermediate read
+     * {@link #Lock} is not required.
+     *
+     * @param key
+     * @param operator
+     * @param value
+     * @param value2
+     * @param record
+     * @return A set of values associated with {@code key} in {@code record} that are satisfying.
+     *         Empty if no satisfying value exists.
+     */
+    public Set<Value> verifyUnsafe(String key, Operator operator, TObject value, TObject value2, long record);
 }

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Engine.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Engine.java
@@ -16,10 +16,7 @@
 package com.cinchapi.concourse.server.storage;
 
 import java.io.File;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Timer;
@@ -872,6 +869,56 @@ public final class Engine extends BufferedStore implements
     }
 
     @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, long record) {
+        transportLock.readLock().lock();
+        Lock read = lockService.getReadLock(key, record);
+        read.lock();
+        try {
+            return inventory.contains(record) ? super.verify(key, operator, value, record) : new HashSet<>();
+        }
+        finally {
+            read.unlock();
+            transportLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, long record, long timestamp) {
+        transportLock.readLock().lock();
+        try {
+            return inventory.contains(record) ? super.verify(key, operator, value, record, timestamp) : new HashSet<>();
+        }
+        finally {
+            transportLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record) {
+        transportLock.readLock().lock();
+        Lock read = lockService.getReadLock(key, record);
+        read.lock();
+        try {
+            return inventory.contains(record) ? super.verify(key, operator, value, value2, record) : new HashSet<>();
+        }
+        finally {
+            read.unlock();
+            transportLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record, long timestamp) {
+        transportLock.readLock().lock();
+        try {
+            return inventory.contains(record) ? super.verify(key, operator, value, value2, record, timestamp) : new HashSet<>();
+        }
+        finally {
+            transportLock.readLock().unlock();
+        }
+    }
+
+    @Override
     public boolean verifyUnsafe(String key, TObject value, long record) {
         transportLock.readLock().lock();
         try {
@@ -882,6 +929,29 @@ public final class Engine extends BufferedStore implements
             transportLock.readLock().unlock();
         }
     }
+
+    @Override
+    public Set<Value> verifyUnsafe(String key, Operator operator, TObject value, long record) {
+        transportLock.readLock().lock();
+        try {
+            return inventory.contains(record) ? super.verify(key, operator, value, record) : new HashSet<>();
+        }
+        finally {
+            transportLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Set<Value> verifyUnsafe(String key, Operator operator, TObject value, TObject value2, long record) {
+        transportLock.readLock().lock();
+        try {
+            return inventory.contains(record) ? super.verify(key, operator, value, value2, record) : new HashSet<>();
+        }
+        finally {
+            transportLock.readLock().unlock();
+        }
+    }
+
 
     @Override
     protected Map<Long, Set<TObject>> doExplore(long timestamp, String key,

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Store.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Store.java
@@ -18,6 +18,7 @@ package com.cinchapi.concourse.server.storage;
 import java.util.Map;
 import java.util.Set;
 
+import com.cinchapi.concourse.server.model.Value;
 import com.cinchapi.concourse.thrift.Operator;
 import com.cinchapi.concourse.thrift.TObject;
 
@@ -356,4 +357,73 @@ public interface Store {
      */
     public boolean verify(String key, TObject value, long record, long timestamp);
 
+    /**
+     * Verify {@code key} has a value that satisfies {@code operator}
+     * in relation to {@code value} in {@code record}.
+     * <p>
+     * This method checks that there is <em>currently</em> a mapping from
+     * {@code key} to a satisfying value in {@code record}.
+     * </p>
+     *
+     * @param key
+     * @param operator
+     * @param value
+     * @param record
+     * @return A set of values associated with {@code key} in {@code record} that are satisfying.
+     *         Empty if no satisfying value exists.
+     */
+    public Set<Value> verify(String key, Operator operator, TObject value, long record);
+
+    /**
+     * Verify {@code key} has a value that satisfies {@code operator}
+     * in relation to {@code value} in {@code record} at {@code timestamp}.
+     *
+     * This method checks that there was a mapping from {@code key} to a satisfying
+     * {@code value} in {@code record} at {@code timestamp}.
+     *
+     * @param key
+     * @param operator
+     * @param value
+     * @param record
+     * @param timestamp
+     * @return A set of values associated with {@code key} in {@code record} that are satisfying.
+     *         Empty if no satisfying value exists.
+     */
+    public Set<Value> verify(String key, Operator operator, TObject value, long record, long timestamp);
+
+    /**
+     * Verify {@code key} has a value that satisfies {@code operator}
+     * in relation to {@code value} and {@code value2} in {@code record}.
+     * <p>
+     * This method checks that there is <em>currently</em> a mapping from
+     * {@code key} to a satisfying value in {@code record}.
+     * </p>
+     *
+     * @param key
+     * @param operator
+     * @param value
+     * @param value2
+     * @param record
+     * @return A set of values associated with {@code key} in {@code record} that are satisfying.
+     *         Empty if no satisfying value exists.
+     */
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record);
+
+    /**
+     * Verify {@code key} has a value that satisfies {@code operator}
+     * in relation to {@code value} and {@code value2} in {@code record} at {@code timestamp}.
+     *
+     * This method checks that there was a mapping from {@code key} to a satisfying
+     * {@code value} in {@code record} at {@code timestamp}.
+     *
+     * @param key
+     * @param operator
+     * @param value
+     * @param value2
+     * @param record
+     * @param timestamp
+     * @return A set of values associated with {@code key} in {@code record} that are satisfying.
+     *         Empty if no satisfying value exists.
+     */
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record, long timestamp);
 }

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Transaction.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/Transaction.java
@@ -32,6 +32,7 @@ import com.cinchapi.concourse.server.concurrent.RangeLockService;
 import com.cinchapi.concourse.server.concurrent.Token;
 import com.cinchapi.concourse.server.io.ByteableCollections;
 import com.cinchapi.concourse.server.io.FileSystem;
+import com.cinchapi.concourse.server.model.Value;
 import com.cinchapi.concourse.server.storage.temp.Queue;
 import com.cinchapi.concourse.server.storage.temp.Write;
 import com.cinchapi.concourse.thrift.Operator;
@@ -265,6 +266,16 @@ public final class Transaction extends AtomicOperation implements AtomicSupport 
     @Override
     public boolean verifyUnsafe(String key, TObject value, long record) {
         return verify(key, value, record);
+    }
+
+    @Override
+    public Set<Value> verifyUnsafe(String key, Operator operator, TObject value, long record) {
+        return verify(key, operator, value, record);
+    }
+
+    @Override
+    public Set<Value> verifyUnsafe(String key, Operator operator, TObject value, TObject value2, long record) {
+        return verify(key, operator, value, value2, record);
     }
 
     /**

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/db/Database.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/db/Database.java
@@ -529,6 +529,34 @@ public final class Database extends BaseStore implements PermanentStore {
                 Value.wrap(value), timestamp);
     }
 
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, long record) {
+        Text key0 = Text.wrapCached(key);
+        return getPrimaryRecord(PrimaryKey.wrap(record), key0).verify(key0,
+                operator, Value.wrap(value));
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, long record, long timestamp) {
+        Text key0 = Text.wrapCached(key);
+        return getPrimaryRecord(PrimaryKey.wrap(record), key0).verify(key0,
+                operator, Value.wrap(value), timestamp);
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record) {
+        Text key0 = Text.wrapCached(key);
+        return getPrimaryRecord(PrimaryKey.wrap(record), key0).verify(key0,
+                operator, Value.wrap(value), Value.wrap(value2));
+    }
+
+    @Override
+    public Set<Value> verify(String key, Operator operator, TObject value, TObject value2, long record, long timestamp) {
+        Text key0 = Text.wrapCached(key);
+        return getPrimaryRecord(PrimaryKey.wrap(record), key0).verify(key0,
+                operator, Value.wrap(value), Value.wrap(value2), timestamp);
+    }
+
     /**
      * Return the PrimaryRecord identifier by {@code primaryKey}.
      * 

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/temp/Buffer.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/storage/temp/Buffer.java
@@ -826,6 +826,18 @@ public final class Buffer extends Limbo implements InventoryTracker {
     }
 
     @Override
+    public Set<Value> verify(Write write, Operator operator, long timestamp, Set<Value> destValues) {
+        numVerifyRequests.incrementAndGet();
+        return super.verify(write, operator, timestamp, destValues);
+    }
+
+    @Override
+    public Set<Value> verify(Write write, Write write2, Operator operator, long timestamp, Set<Value> destValues) {
+        numVerifyRequests.incrementAndGet();
+        return super.verify(write, write2, operator, timestamp, destValues);
+    }
+
+    @Override
     public TernaryTruth verifyFast(Write write, long timestamp) {
         if(inventory.contains(write.getRecord().longValue())) {
             return super.verifyFast(write, timestamp);

--- a/interface/concourse.thrift
+++ b/interface/concourse.thrift
@@ -2806,6 +2806,87 @@ service ConcourseService {
     2: exceptions.TransactionException ex2,
     3: exceptions.ParseException ex3);
 
+  bool verifyKeyOperatorValueRecord(
+    1: string key,
+    2: shared.Operator operator,
+    3: data.TObject value,
+    4: i64 record,
+    5: shared.AccessToken creds,
+    6: shared.TransactionToken transaction,
+    7: string environment)
+  throws (
+    1: exceptions.SecurityException ex,
+    2: exceptions.TransactionException ex2);
+
+  bool verifyKeyOperatorValueRecordTime(
+    1: string key,
+    2: shared.Operator operator,
+    3: data.TObject value,
+    4: i64 record,
+    5: i64 timestamp,
+    6: shared.AccessToken creds,
+    7: shared.TransactionToken transaction,
+    8: string environment)
+  throws (
+    1: exceptions.SecurityException ex,
+    2: exceptions.TransactionException ex2);
+
+  bool verifyKeyOperatorValueRecordTimestr(
+    1: string key,
+    2: shared.Operator operator,
+    3: data.TObject value,
+    4: i64 record,
+    5: string timestamp,
+    6: shared.AccessToken creds,
+    7: shared.TransactionToken transaction,
+    8: string environment)
+  throws (
+    1: exceptions.SecurityException ex,
+    2: exceptions.TransactionException ex2,
+    3: exceptions.ParseException ex3);
+
+  bool verifyKeyOperatorValueValueRecord(
+    1: string key,
+    2: shared.Operator operator,
+    3: data.TObject value,
+    4: data.TObject value2,
+    5: i64 record,
+    6: shared.AccessToken creds,
+    7: shared.TransactionToken transaction,
+    8: string environment)
+  throws (
+    1: exceptions.SecurityException ex,
+    2: exceptions.TransactionException ex2);
+
+  bool verifyKeyOperatorValueValueRecordTime(
+    1: string key,
+    2: shared.Operator operator,
+    3: data.TObject value,
+    4: data.TObject value2,
+    5: i64 record,
+    6: i64 timestamp,
+    7: shared.AccessToken creds,
+    8: shared.TransactionToken transaction,
+    9: string environment)
+  throws (
+    1: exceptions.SecurityException ex,
+    2: exceptions.TransactionException ex2);
+
+  bool verifyKeyOperatorValueValueRecordTimestr(
+    1: string key,
+    2: shared.Operator operator,
+    3: data.TObject value,
+    4: data.TObject value2,
+    5: i64 record,
+    6: string timestamp,
+    7: shared.AccessToken creds,
+    8: shared.TransactionToken transaction,
+    9: string environment)
+  throws (
+    1: exceptions.SecurityException ex,
+    2: exceptions.TransactionException ex2,
+    3: exceptions.ParseException ex3);
+
   string jsonifyRecords(
     1: list<i64> records,
     2: bool identifier,


### PR DESCRIPTION
This implementation covers the less than (or equal), greater than (or equal), and between operators. I implemented the Java API, but I have not touched the PHP, Python, or Ruby APIs. Also, I have not integrated this with CASH yet.