### PR TITLE
(CON-555) Making default constructor public so that ObjectResultDataset can be constructed easily

### DIFF
--- a/concourse-plugin-core/src/main/java/com/cinchapi/concourse/server/plugin/data/ObjectResultDataset.java
+++ b/concourse-plugin-core/src/main/java/com/cinchapi/concourse/server/plugin/data/ObjectResultDataset.java
@@ -59,7 +59,7 @@ public class ObjectResultDataset extends ResultDataset<Object> {
     /**
      * Construct a new instance.
      */
-    protected ObjectResultDataset(){
+    public ObjectResultDataset(){
         this.thrift = new TObjectResultDataset();
     }
 


### PR DESCRIPTION
Just for convenience, so that instantiation does not require the clunky notation:

```java
Dataset<Long, String, Object> dataset = new ObjectResultDataset(new TObjectResultDataset());
```

and can instead be

```java
Dataset<Long, String, Object> dataset = new ObjectResultDataset();
```