### PR TITLE
CON-590: Ignore SecurityException thrown on ManagementCli exit

### DIFF
--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/cli/core/ManagementCli.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/cli/core/ManagementCli.java
@@ -216,6 +216,11 @@ public abstract class ManagementCli {
             try {
                 client.logout(token);
             }
+            catch (com.cinchapi.concourse.thrift.SecurityException e) {
+                // CON-590: The token has been invalidated, but we can ignore
+                // it at this point since the work that requires authorization
+                // has already been done.
+            }
             catch (TException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This commit adds logic to ignore a SecurityException being raised in the
exit method of a ManagementCli. The exception happens because the token
that was being using in the CLI has become invalid. It is safe to ignore
the token on exit because the work that requires authorization has already
been completed.