### PR TITLE
CON-442: Add robust logic to ensure ManagedConcourseServer is installed across versions without hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Fixed a bug that caused the server to fail to start if the `conf/stopwords.txt` configuration file did not exist.
 * Added the ability for the storage engine to track stats and metadata about database structures.
 
+#### Version 0.8.2 (April 17, 2018)
+* Fixed a bug in the `ManagedConcourseServer#install` method that caused the server installation to randomly fail due to race conditions. This caused unit tests that extended the `concourse-ete-test-core` framework to intermittently fail.
+
 #### Version 0.8.1 (March 26, 2018)
 * Fixed a bug that caused local CCL resolution to not work in the `findOrInsert` methods.
 * Fixed an issue that caused conversion from string to `Operator` to be case sensitive.

--- a/concourse-ete-test-core/src/test/java/com/cinchapi/concourse/server/ManagedConcourseServerInstallTest.java
+++ b/concourse-ete-test-core/src/test/java/com/cinchapi/concourse/server/ManagedConcourseServerInstallTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2013-2018 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.concourse.server;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the installability of various Concourse versions using the
+ * {@link ManagedConcourseServer} framework.
+ *
+ * @author Jeff Nelson
+ */
+public class ManagedConcourseServerInstallTest {
+
+    @Test
+    public void testInstallVersion0_8_1() {
+        testInstall(ManagedConcourseServer.manageNewServer("0.8.1"));
+    }
+
+    @Test
+    public void testInstallVersionBefore0_5_0DoesNotHang() {
+        testInstall(ManagedConcourseServer.manageNewServer("0.4.4"));
+        // An "error" occurs in the shutdown hook that checks to see if the
+        // server is still running because the Tanuki control script (used
+        // before version 0.5) returns an exit code of 1 on the "status"
+        // command...
+        System.out.println("IGNORE EXCEPTION STACKTRACE!!!");
+    }
+
+    /**
+     * Utility method to test installability of a given server.
+     * 
+     * @param server
+     */
+    private static void testInstall(ManagedConcourseServer server) {
+        server.start();
+        server.stop();
+        Assert.assertTrue(true); // lack of exception means test passes...
+    }
+
+}


### PR DESCRIPTION
This commit adds more intelligent that will only forcibly kill the process in older versions of Concourse that don't support the skip-integration flag