### PR TITLE
adjusted flag value as result of JEP-245

### DIFF
--- a/concourse-server/scripts/concourse
+++ b/concourse-server/scripts/concourse
@@ -57,7 +57,7 @@ JVMOPTS="
 -Dcom.sun.management.jmxremote.authenticate=false
 -Dcom.sun.management.jmxremote.ssl=false
 -XX:+UseThreadPriorities
--XX:ThreadPriorityPolicy=42
+-XX:ThreadPriorityPolicy=1
 -XX:CompileThreshold=500
 "
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Fix for higher version of Java that correct JVM flag "hack", JEP-245.