### PR TITLE
Updated the README with working documentation links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ where
 * bug fixes or miscellaneous changes bumps the patch.
 
 ##### Additional Resources
-* [Installation](https://cinchapi.github.io/concourse/installation)
-* [Introduction](https://cinchapi.github.io/concourse/introduction)
+* [Installation](https://docs.cinchapi.com/concourse/installation)
+* [Introduction](https://docs.cinchapi.com/concourse/introduction)
 * [API](concourse-driver-java/README.md)
 * [Developer Setup](http://wiki.cinchapi.com/display/OSS/Concourse+Developer+Setup)
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ where
 * bug fixes or miscellaneous changes bumps the patch.
 
 ##### Additional Resources
-* [Installation](https://docs.cinchapi.com/concourse/guide/installation/)
-* [Introduction](https://docs.cinchapi.com/concourse/guide/introduction/)
+* [Installation](https://cinchapi.github.io/concourse/installation)
+* [Introduction](https://cinchapi.github.io/concourse/introduction)
 * [API](concourse-driver-java/README.md)
 * [Developer Setup](http://wiki.cinchapi.com/display/OSS/Concourse+Developer+Setup)
 


### PR DESCRIPTION
The current documentation links are broken. Until the official documentation website is updated/fixed, it makes sense to at least link directly to the documentation that’s automatically deployed during the builds.