### PR TITLE
Fix corner case with bootstrapping system version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 
 ##### Miscellaneous
 * Added a separate log file for upgrade tasks (`log/upgrade.log`).
+
+#### Version 0.10.6
+* Fixed a bug that caused the system version to be set incorrectly when a newly installed instance of Concourse Server (e.g. not upgraded) utilized data directories containing data from an older system version. This bug caused some upgrade tasks to be skipped, placing the system in an unstable state.
  
 #### Version 0.10.5 (August 22, 2020)
 * Fixed a bug where sorting on a navigation key that isn't fetched (e.g. using a navigation key in a `find` operation or not specifying the navigation key as an operation key in a `get` or `select` operation), causes the results set to be returned in the incorrect order.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ##### Miscellaneous
 * Added a separate log file for upgrade tasks (`log/upgrade.log`).
 
-#### Version 0.10.6
+##### Bug Fixes
 * Fixed a bug that caused the system version to be set incorrectly when a newly installed instance of Concourse Server (e.g. not upgraded) utilized data directories containing data from an older system version. This bug caused some upgrade tasks to be skipped, placing the system in an unstable state.
  
 #### Version 0.10.5 (August 22, 2020)

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/upgrade/UpgradeTask.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/upgrade/UpgradeTask.java
@@ -55,14 +55,70 @@ public abstract class UpgradeTask implements Comparable<UpgradeTask> {
      */
     @Restricted
     public static void setCurrentSystemVersion(int version) {
-        ((MappedByteBuffer) FileSystem
-                .map(BUFFER_VERSION_FILE, MapMode.READ_WRITE, 0, 4)
-                .putInt(version)).force();
-        ((MappedByteBuffer) FileSystem
-                .map(DB_VERSION_FILE, MapMode.READ_WRITE, 0, 4).putInt(version))
-                        .force();
-        ((MappedByteBuffer) FileSystem
-                .map(HOME_VERSION_FILE, MapMode.READ_WRITE, 0, 4)
+        setBufferCurrentSystemVersion(version);
+        setDatabaseCurrentSystemVersion(version);
+        setHomeCurrentSystemVersion(version);
+    }
+
+    /**
+     * Update the system version in the buffer data files.
+     * <p>
+     * <strong>WARNING:</strong> Setting the system version in individual
+     * locations is not recommended because lack of consensus about the system
+     * version can cause unexpected results. It is best to use the
+     * {@link #setCurrentSystemVersion(int)} method unless this method is being
+     * called for a known special case.
+     * <p>
+     * 
+     * @param version
+     */
+    @Restricted
+    static void setBufferCurrentSystemVersion(int version) {
+        writeCurrentSystemVersion(BUFFER_VERSION_FILE, version);
+    }
+
+    /**
+     * Update the system version in the database data files.
+     * <p>
+     * <strong>WARNING:</strong> Setting the system version in individual
+     * locations is not recommended because lack of consensus about the system
+     * version can cause unexpected results. It is best to use the
+     * {@link #setCurrentSystemVersion(int)} method unless this method is being
+     * called for a known special case.
+     * <p>
+     * 
+     * @param version
+     */
+    @Restricted
+    static void setDatabaseCurrentSystemVersion(int version) {
+        writeCurrentSystemVersion(DB_VERSION_FILE, version);
+    }
+
+    /**
+     * Update the system version in the server home directory.
+     * <p>
+     * <strong>WARNING:</strong> Setting the system version in individual
+     * locations is not recommended because lack of consensus about the system
+     * version can cause unexpected results. It is best to use the
+     * {@link #setCurrentSystemVersion(int)} method unless this method is being
+     * called for a known special case.
+     * <p>
+     * 
+     * @param version
+     */
+    @Restricted
+    static void setHomeCurrentSystemVersion(int version) {
+        writeCurrentSystemVersion(HOME_VERSION_FILE, version);
+    }
+
+    /**
+     * Write out the system {@code version} to the {@code file}.
+     * 
+     * @param file
+     * @param version
+     */
+    private static void writeCurrentSystemVersion(String file, int version) {
+        ((MappedByteBuffer) FileSystem.map(file, MapMode.READ_WRITE, 0, 4)
                 .putInt(version)).force();
     }
 

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/upgrade/UpgradeTasks.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/upgrade/UpgradeTasks.java
@@ -126,7 +126,6 @@ public final class UpgradeTasks {
      */
     private static int bootstrap() {
         String seal = ".douge";
-        int currentSystemVersion = getCurrentSystemVersion();
         if(FileSystem.hasFile(seal)) {
             UpgradeTask theTask = null;
             // Go through the upgrade tasks and find the one with the largest
@@ -144,14 +143,19 @@ public final class UpgradeTasks {
                     }
                 }
             }
-            UpgradeTask.setCurrentSystemVersion(theTask.version());
-            Logger.upgradeInfo("The upgrade framework has been initialized "
-                    + "with a system version of {}", theTask.version());
+            UpgradeTask.setHomeCurrentSystemVersion(theTask.version());
+            Logger.upgradeInfo(
+                    "It appears that this is a fresh installation of "
+                            + "Concourse Server, so the upgrade framework has been "
+                            + "initialized with a system version of {}. Standby for "
+                            + "detection of whether there are existing data files with "
+                            + "a different system version; necessitating the possible "
+                            + "application of upgrade tasks to make the system fully "
+                            + "consistent.",
+                    theTask.version());
             FileSystem.deleteFile(seal);
-            return theTask.version();
-
         }
-        return currentSystemVersion;
+        return getCurrentSystemVersion();
     }
 
 }


### PR DESCRIPTION
This fixes a bug that occurs when a fresh install with upgrade tasks is pointed to an data directory with existing data at an older system version. Previously, the bootstrap process set the system version across the buffer, db and home with the latest system version (without running the upgrade tasks). This fix adjusts the bootstrap process to only set the home system version if it detects that the install is fresh