### PR TITLE
Fixed a bug with min/max calculations of an index as a CCL operation value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added `DEBUG` logging that provides details on the execution path chosen for each lookup.
 * Fixed a bug that caused `Order`/`Sort` instructions that contain multiple clauses referencing the same key to drop all but the last clause for that key.
 * Fixed a bug that caused the `concourse export` CLI to not process some combinations of command line arguments properly.
+* Fixed a bug tha caused an error to be thrown when using the `max` or `min` function over an entire index as an operation value in a CCL statement.
 
 #### Version 0.11.0 (March 4, 2022)
 

--- a/concourse-integration-tests/src/test/java/com/cinchapi/concourse/CclFunctionsTest.java
+++ b/concourse-integration-tests/src/test/java/com/cinchapi/concourse/CclFunctionsTest.java
@@ -316,4 +316,39 @@ public class CclFunctionsTest extends ConcourseIntegrationTest {
         Assert.assertEquals(expected, actual);
     }
 
+    @Test
+    public void testUseMaxKeyAsEvaluationValue() {
+        setupDatabaseKey(client);
+        client.select("age", "age | average > max(age)");
+        Assert.assertTrue(true); // lack of Exception means the test passes
+    }
+
+    @Test
+    public void testUseMinKeyAsEvaluationValue() {
+        setupDatabaseKey(client);
+        client.select("age", "age | average > min(age)");
+        Assert.assertTrue(true); // lack of Exception means the test passes
+    }
+
+    @Test
+    public void testUseAverageKeyAsEvaluationValue() {
+        setupDatabaseKey(client);
+        client.select("age", "age | average > average(age)");
+        Assert.assertTrue(true); // lack of Exception means the test passes
+    }
+
+    @Test
+    public void testUseCountKeyAsEvaluationValue() {
+        setupDatabaseKey(client);
+        client.select("age", "age | average > count(age)");
+        Assert.assertTrue(true); // lack of Exception means the test passes
+    }
+
+    @Test
+    public void testUseSumKeyAsEvaluationValue() {
+        setupDatabaseKey(client);
+        client.select("age", "age | average > sum(age)");
+        Assert.assertTrue(true); // lack of Exception means the test passes
+    }
+
 }

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ConcourseServer.java
@@ -3768,8 +3768,8 @@ public class ConcourseServer extends BaseConcourseServer implements
             throws TException {
         AtomicSupport store = getStore(transaction, environment);
         return AtomicOperations.supplyWithRetry(store, (atomic) -> {
-            Map<TObject, Set<Long>> data = atomic.browse(key);
-            return Iterables.getLast(data.keySet(), null);
+            Number min = Operations.maxKeyAtomic(key, Time.NONE, atomic);
+            return Convert.javaToThrift(min);
         });
     }
 
@@ -3959,8 +3959,8 @@ public class ConcourseServer extends BaseConcourseServer implements
             throws SecurityException, TransactionException, TException {
         AtomicSupport store = getStore(transaction, environment);
         return AtomicOperations.supplyWithRetry(store, (atomic) -> {
-            Map<TObject, Set<Long>> data = atomic.browse(key, timestamp);
-            return Iterables.getLast(data.keySet(), null);
+            Number min = Operations.maxKeyAtomic(key, timestamp, atomic);
+            return Convert.javaToThrift(min);
         });
     }
 
@@ -3982,8 +3982,8 @@ public class ConcourseServer extends BaseConcourseServer implements
             throws TException {
         AtomicSupport store = getStore(transaction, environment);
         return AtomicOperations.supplyWithRetry(store, (atomic) -> {
-            Map<TObject, Set<Long>> data = atomic.browse(key);
-            return Iterables.getFirst(data.keySet(), null);
+            Number min = Operations.minKeyAtomic(key, Time.NONE, atomic);
+            return Convert.javaToThrift(min);
         });
     }
 
@@ -4174,8 +4174,8 @@ public class ConcourseServer extends BaseConcourseServer implements
             throws TException {
         AtomicSupport store = getStore(transaction, environment);
         return AtomicOperations.supplyWithRetry(store, (atomic) -> {
-            Map<TObject, Set<Long>> data = atomic.browse(key, timestamp);
-            return Iterables.getFirst(data.keySet(), null);
+            Number min = Operations.minKeyAtomic(key, timestamp, atomic);
+            return Convert.javaToThrift(min);
         });
     }
 

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Operations.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Operations.java
@@ -124,6 +124,30 @@ public final class Operations {
         return avg;
     }
 
+    public static Number minKeyAtomic(String key, long timestamp, Store store) {
+        checkAtomicity(store, timestamp);
+        Map<TObject, Set<Long>> data = Stores.browse(store, key, timestamp);
+        TObject min = Iterables.getFirst(data.keySet(), null);
+        if(min != null) {
+            return (Number) Convert.thriftToJava(min);
+        }
+        else {
+            return null;
+        }
+    }
+
+    public static Number maxKeyAtomic(String key, long timestamp, Store store) {
+        checkAtomicity(store, timestamp);
+        Map<TObject, Set<Long>> data = Stores.browse(store, key, timestamp);
+        TObject max = Iterables.getLast(data.keySet(), null);
+        if(max != null) {
+            return (Number) Convert.thriftToJava(max);
+        }
+        else {
+            return null;
+        }
+    }
+
     /**
      * Use the provided {@code store} to atomically add each of the values in
      * {@code key}/{@code record} at {@code timestamp} to the running

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Operations.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Operations.java
@@ -124,30 +124,6 @@ public final class Operations {
         return avg;
     }
 
-    public static Number minKeyAtomic(String key, long timestamp, Store store) {
-        checkAtomicity(store, timestamp);
-        Map<TObject, Set<Long>> data = Stores.browse(store, key, timestamp);
-        TObject min = Iterables.getFirst(data.keySet(), null);
-        if(min != null) {
-            return (Number) Convert.thriftToJava(min);
-        }
-        else {
-            return null;
-        }
-    }
-
-    public static Number maxKeyAtomic(String key, long timestamp, Store store) {
-        checkAtomicity(store, timestamp);
-        Map<TObject, Set<Long>> data = Stores.browse(store, key, timestamp);
-        TObject max = Iterables.getLast(data.keySet(), null);
-        if(max != null) {
-            return (Number) Convert.thriftToJava(max);
-        }
-        else {
-            return null;
-        }
-    }
-
     /**
      * Use the provided {@code store} to atomically add each of the values in
      * {@code key}/{@code record} at {@code timestamp} to the running
@@ -736,6 +712,27 @@ public final class Operations {
 
     /**
      * Use the {@code store} to atomically compute the max across all the values
+     * stored for {@code key} across all records at {@code timestamp}.
+     * 
+     * @param key
+     * @param timestamp
+     * @param store
+     * @return the max
+     */
+    public static Number maxKeyAtomic(String key, long timestamp, Store store) {
+        checkAtomicity(store, timestamp);
+        Map<TObject, Set<Long>> data = Stores.browse(store, key, timestamp);
+        TObject max = Iterables.getLast(data.keySet(), null);
+        if(max != null) {
+            return (Number) Convert.thriftToJava(max);
+        }
+        else {
+            return null;
+        }
+    }
+
+    /**
+     * Use the {@code store} to atomically compute the max across all the values
      * stored for {@code key} in {@code record} at {@code timestamp}.
      * 
      * @param key the field name
@@ -769,6 +766,27 @@ public final class Operations {
                     Calculations.maxKeyRecord());
         }
         return max;
+    }
+
+    /**
+     * Use the {@code store} to atomically compute the min across all the values
+     * stored for {@code key} across all records at {@code timestamp}.
+     * 
+     * @param key
+     * @param timestamp
+     * @param store
+     * @return the max
+     */
+    public static Number minKeyAtomic(String key, long timestamp, Store store) {
+        checkAtomicity(store, timestamp);
+        Map<TObject, Set<Long>> data = Stores.browse(store, key, timestamp);
+        TObject min = Iterables.getFirst(data.keySet(), null);
+        if(min != null) {
+            return (Number) Convert.thriftToJava(min);
+        }
+        else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
…`min` function over an entire index as an operation value in a CCL statement.