### PR TITLE
Fix user defined transaction write toggling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### Version 0.11.2 (TBD)
+* Fixed a bug that caused Concourse Server to incorrectly detect when an attempt was made to atomically commit multiple Writes that toggle the state of a field (e.g. `ADD name as jeff in 1`, `REMOVE name as jeff in 1`, `ADD name as jeff in 1`) in user-defined `transactions`. As a result of this bug, all field toggling Writes were committed instead of the desired behaviour where there was a commit of at most one equal Write that was required to obtain the intended field state. Committing multiple writes that toggled the field state within the same transaction could cause failures, unexplained results or fatal inconsistencies when reconciling data.
+
 #### Version 0.11.1 (March 9, 2022)
 * Upgraded to CCL version `3.1.2` to fix a regression that caused parenthetical expressions within a Condition containing `LIKE` `REGEX`, `NOT_LIKE` and `NOT_REGEX` operators to mistakenly throw a `SyntaxException` when being parsed.
 * Added the `ConcourseCompiler#evaluate(ConditionTree, Multimap)` method that uses the `Operators#evaluate` static method to perform local evaluation.

--- a/concourse-integration-tests/src/test/java/com/cinchapi/concourse/TransactionWorkflowTest.java
+++ b/concourse-integration-tests/src/test/java/com/cinchapi/concourse/TransactionWorkflowTest.java
@@ -15,6 +15,8 @@
  */
 package com.cinchapi.concourse;
 
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
@@ -24,6 +26,8 @@ import com.cinchapi.concourse.lang.Criteria;
 import com.cinchapi.concourse.test.ConcourseIntegrationTest;
 import com.cinchapi.concourse.thrift.Operator;
 import com.cinchapi.concourse.time.Time;
+import com.cinchapi.concourse.util.Numbers;
+import com.cinchapi.concourse.util.Random;
 import com.cinchapi.concourse.util.TestData;
 import com.google.common.base.Strings;
 
@@ -504,6 +508,48 @@ public class TransactionWorkflowTest extends ConcourseIntegrationTest {
         t1.join();
         Assert.assertFalse(committed.get());
         Assert.assertFalse(client.select("name", 1).contains("Ron"));
+    }
+
+    @Test
+    public void testToggledWriteConsolidation() {
+        int number = Random.getScaleCount();
+        int even;
+        int odd;
+        if(Numbers.isEven(number)) {
+            even = number;
+            odd = number + 1;
+        }
+        else {
+            even = number + 1;
+            odd = number;
+        }
+        client.stage();
+        boolean add = true;
+        for (int i = 0; i < even; ++i) {
+            if(add) {
+                client.add("name", "jeff", 1);
+            }
+            else {
+                client.remove("name", "jeff", 1);
+            }
+            add = !add;
+        }
+        add = true;
+        for (int i = 0; i < odd; ++i) {
+            if(add) {
+                client.add("age", 34, 1);
+            }
+            else {
+                client.remove("age", 34, 1);
+            }
+            add = !add;
+        }
+        Assert.assertTrue(client.commit());
+        Map<Timestamp, List<String>> nameReview = client.review("name", 1);
+        Map<Timestamp, List<String>> ageReview = client.review("age", 1);
+        Assert.assertEquals(0, nameReview.size());
+        Assert.assertEquals(1, ageReview.size());
+        Assert.assertEquals(1, ageReview.values().iterator().next().size());
     }
 
 }

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/temp/ToggleQueueTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/temp/ToggleQueueTest.java
@@ -48,15 +48,20 @@ public class ToggleQueueTest extends QueueTest {
         Write add = Write.add("name", Convert.javaToThrift("jeff"), 1);
         Write remove = Write.remove("name", Convert.javaToThrift("jeff"), 1);
         ToggleQueue queue = (ToggleQueue) store;
+        List<Write> writes = queue.getWrites();
         long version = CommitVersions.next();
         queue.insert(remove.rewrite(version));
         Assert.assertEquals(1, Iterators.size(queue.iterator()));
+        Assert.assertEquals(1, Iterators.size(writes.iterator()));
         queue.insert(add.rewrite(version));
-        Assert.assertEquals(0, Iterators.size(queue.iterator()));
-        queue.insert(remove);
-        Assert.assertEquals(1, Iterators.size(queue.iterator()));
-        queue.insert(add);
         Assert.assertEquals(2, Iterators.size(queue.iterator()));
+        Assert.assertEquals(0, Iterators.size(writes.iterator()));
+        queue.insert(remove);
+        Assert.assertEquals(3, Iterators.size(queue.iterator()));
+        Assert.assertEquals(1, Iterators.size(writes.iterator()));
+        queue.insert(add);
+        Assert.assertEquals(4, Iterators.size(queue.iterator()));
+        Assert.assertEquals(0, Iterators.size(writes.iterator()));
     }
 
     @Test


### PR DESCRIPTION
Fixed a bug that caused Concourse Server to incorrectly detect when an attempt was made to atomically commit multiple Writes that toggle the state of a field (e.g. `ADD name as jeff in 1`, `REMOVE name as jeff in 1`, `ADD name as jeff in 1`) in user-defined `transactions`. As a result of this bug, all field toggling Writes were committed instead of the desired behaviour where there was a commit of at most one equal Write that was required to obtain the intended field state. Committing multiple writes that toggled the field state within the same transaction could cause failures, unexplained results or fatal inconsistencies when reconciling data.