### PR TITLE
Use traditional buffer instead of memory mapped files when reading from database files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Version 0.11.2 (TBD)
 * Fixed a bug that caused Concourse Server to incorrectly detect when an attempt was made to atomically commit multiple Writes that toggle the state of a field (e.g. `ADD name as jeff in 1`, `REMOVE name as jeff in 1`, `ADD name as jeff in 1`) in user-defined `transactions`. As a result of this bug, all field toggling Writes were committed instead of the desired behaviour where there was a commit of at most one equal Write that was required to obtain the intended field state. Committing multiple writes that toggled the field state within the same transaction could cause failures, unexplained results or fatal inconsistencies when reconciling data.
+* Switched from using memory mapped files in favor of traditional buffering while reading data from Segment files in order to avoid a potential issue where Concourse Server very quickly exceeded the maximum number of mappings allowed on some Linux systems (as specified by the `vm.max_map_count` property).
 
 #### Version 0.11.1 (March 9, 2022)
 * Upgraded to CCL version `3.1.2` to fix a regression that caused parenthetical expressions within a Condition containing `LIKE` `REGEX`, `NOT_LIKE` and `NOT_REGEX` operators to mistakenly throw a `SyntaxException` when being parsed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Version 0.11.2 (TBD)
 * Fixed a bug that caused Concourse Server to incorrectly detect when an attempt was made to atomically commit multiple Writes that toggle the state of a field (e.g. `ADD name as jeff in 1`, `REMOVE name as jeff in 1`, `ADD name as jeff in 1`) in user-defined `transactions`. As a result of this bug, all field toggling Writes were committed instead of the desired behaviour where there was a commit of at most one equal Write that was required to obtain the intended field state. Committing multiple writes that toggled the field state within the same transaction could cause failures, unexplained results or fatal inconsistencies when reconciling data.
-* Switched from using memory mapped files in favor of traditional buffering while reading data from Segment files in order to avoid a potential issue where Concourse Server very quickly exceeded the maximum number of mappings allowed on some Linux systems (as specified by the `vm.max_map_count` property).
+* Switched from using memory mapped files in favor of traditional buffering when reading data from Segment files. This change avoids a potential issue where Concourse Server could very quickly exceeded the maximum number of mappings allowed on some Linux systems (as specified by the `vm.max_map_count` property).
 
 #### Version 0.11.1 (March 9, 2022)
 * Upgraded to CCL version `3.1.2` to fix a regression that caused parenthetical expressions within a Condition containing `LIKE` `REGEX`, `NOT_LIKE` and `NOT_REGEX` operators to mistakenly throw a `SyntaxException` when being parsed.

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
@@ -218,13 +218,12 @@ class ByteableCollectionStreamIterator implements
     private void read(int size) {
         try {
             buffer = ByteBuffer.allocate(size);
-            int read = 0;
-            while (buffer.hasRemaining() && read >= 0) {
-                read += channel.read(buffer, position + read);
+            while (buffer.hasRemaining()
+                    && channel.read(buffer, position) >= 0) {
+                position += buffer.position();
             }
             buffer.flip();
             slice = buffer.duplicate();
-            position += buffer.capacity();
         }
         catch (IOException e) {
             throw CheckedExceptions.wrapAsRuntimeException(e);

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
@@ -218,10 +218,11 @@ class ByteableCollectionStreamIterator implements
     private void read(int size) {
         try {
             buffer = ByteBuffer.allocate(size);
-            while (buffer.hasRemaining()
-                    && channel.read(buffer, position) >= 0) {
-                position += buffer.position();
+            while (buffer.hasRemaining() && channel.read(buffer,
+                    position + buffer.position()) >= 0) {
+                continue;
             }
+            position += buffer.position();
             buffer.flip();
             slice = buffer.duplicate();
         }

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
@@ -219,10 +219,8 @@ class ByteableCollectionStreamIterator implements
         try {
             buffer = ByteBuffer.allocate(size);
             channel.position(position);
-            while (buffer.hasRemaining()) {
-                if(channel.read(buffer) < 0) {
-                    break; // End of stream has been reached
-                }
+            while (buffer.hasRemaining() && channel.read(buffer) >= 0) {
+                continue;
             }
             buffer.flip();
             slice = buffer.duplicate();

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/io/ByteableCollectionStreamIterator.java
@@ -218,13 +218,13 @@ class ByteableCollectionStreamIterator implements
     private void read(int size) {
         try {
             buffer = ByteBuffer.allocate(size);
-            channel.position(position);
-            while (buffer.hasRemaining() && channel.read(buffer) >= 0) {
-                continue;
+            int read = 0;
+            while (buffer.hasRemaining() && read >= 0) {
+                read += channel.read(buffer, position + read);
             }
             buffer.flip();
             slice = buffer.duplicate();
-            position = channel.position();
+            position += buffer.capacity();
         }
         catch (IOException e) {
             throw CheckedExceptions.wrapAsRuntimeException(e);


### PR DESCRIPTION
Switched from using memory mapped files in favor of traditional buffering when reading data from Segment files. This change avoids a potential issue where Concourse Server could very quickly exceeded the maximum number of mappings allowed on some Linux systems (as specified by the `vm.max_map_count` property).