### PR TITLE
Fix v3 storage format duplicate data detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Version 0.11.2 (TBD)
 * Fixed a bug that caused Concourse Server to incorrectly detect when an attempt was made to atomically commit multiple Writes that toggle the state of a field (e.g. `ADD name as jeff in 1`, `REMOVE name as jeff in 1`, `ADD name as jeff in 1`) in user-defined `transactions`. As a result of this bug, all field toggling Writes were committed instead of the desired behaviour where there was a commit of at most one equal Write that was required to obtain the intended field state. Committing multiple writes that toggled the field state within the same transaction could cause failures, unexplained results or fatal inconsistencies when reconciling data.
 * Removed the `DEBUG` logging (added in `0.11.1`) that provides details on the execution path chosen for each lookup because it is too noisy and drastically degrades performance.
+* Fixed a bug in the way that Concourse Server determined if duplicate data existed in the v3 storage files, which caused the `concourse data repair` CLI to no longer work properly (compared to how it worked on the v2 storage files).
 
 #### Version 0.11.1 (March 9, 2022)
 * Upgraded to CCL version `3.1.2` to fix a regression that caused parenthetical expressions within a Condition containing `LIKE` `REGEX`, `NOT_LIKE` and `NOT_REGEX` operators to mistakenly throw a `SyntaxException` when being parsed.

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/db/DatabaseTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/db/DatabaseTest.java
@@ -479,7 +479,7 @@ public class DatabaseTest extends StoreTest {
         db.verify(write.getKey().toString(), write.getValue().getTObject(),
                 write.getRecord().longValue());
         db.select(write.getRecord().longValue());
-        for(Write w : toVerify) {
+        for (Write w : toVerify) {
             Assert.assertTrue(db.verify(w));
         }
     }

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/db/DatabaseTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/storage/db/DatabaseTest.java
@@ -411,6 +411,79 @@ public class DatabaseTest extends StoreTest {
         db.select(write.getRecord().longValue());
     }
 
+    @Test
+    public void testRepairDuplicateDataWithAtomicCommit() {
+        Database db = (Database) store;
+        Set<Write> duplicates = Sets.newHashSet();
+        for (int i = 0; i < 10; ++i) {
+            duplicates.add(
+                    Write.add(TestData.getSimpleString(), TestData.getTObject(),
+                            TestData.getIdentifier().longValue()));
+        }
+        for (Write write : duplicates) {
+            db.accept(write);
+        }
+        db.sync();
+        Write duplicate = null;
+        int count = 0;
+        List<Write> toVerify = Lists.newArrayList();
+        while (count < 5 || duplicate == null) {
+            boolean addDuplicates = TestData.getScaleCount() % 3 == 0;
+            for (int j = 0; j < TestData.getScaleCount(); ++j) {
+                Write write = null;
+                if(addDuplicates && TestData.getScaleCount() % 5 == 0) {
+                    write = Iterables.get(duplicates,
+                            Math.abs(TestData.getInt()) % duplicates.size());
+                    duplicate = MoreObjects.firstNonNull(duplicate, write);
+                }
+                else {
+                    while (write == null || duplicates.contains(write)) {
+                        write = TestData.getWriteAdd();
+                    }
+                }
+                db.accept(write);
+            }
+            // Simulate Atomic Operation
+            Write w1 = Write.add("foo", Convert.javaToThrift(Time.now()),
+                    Time.now());
+            Write w2 = Write.add("foo", Convert.javaToThrift(Time.now()),
+                    Time.now());
+            Write w3 = Write.add("foo", Convert.javaToThrift(Time.now()),
+                    Time.now());
+            toVerify.add(w1);
+            toVerify.add(w2);
+            toVerify.add(w3);
+            db.accept(w1);
+            db.accept(w2.rewrite(w1.getVersion()));
+            db.accept(w3.rewrite(w1.getVersion()));
+            db.sync();
+            ++count;
+        }
+        Write write = duplicate;
+        try {
+            db.verify(write.getKey().toString(), write.getValue().getTObject(),
+                    write.getRecord().longValue());
+            Assert.fail("Expected an unoffset Write exception");
+        }
+        catch (Exception e) {
+            Assert.assertTrue(true);
+        }
+        try {
+            db.select(write.getRecord().longValue());
+            Assert.fail("Expected an unoffset Write exception");
+        }
+        catch (Exception e) {
+            Assert.assertTrue(true);
+        }
+        db.repair();
+        db.verify(write.getKey().toString(), write.getValue().getTObject(),
+                write.getRecord().longValue());
+        db.select(write.getRecord().longValue());
+        for(Write w : toVerify) {
+            Assert.assertTrue(db.verify(w));
+        }
+    }
+
     @Override
     protected void add(String key, TObject value, long record) {
         if(!store.verify(key, value, record)) {


### PR DESCRIPTION
Fixed a bug in the way that Concourse Server determined if duplicate data existed in the v3 storage files, which caused the `concourse data repair` CLI to no longer work properly (compared to how it worked on the v2 storage files).