### PR TITLE
Fix memory leak when reading Values from disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Switched from using memory mapped files in favor of traditional buffering when reading data from Segment files. This change avoids a potential issue where Concourse Server could very quickly exceeded the maximum number of mappings allowed on some Linux systems (as specified by the `vm.max_map_count` property).
 * Removed the `DEBUG` logging (added in `0.11.1`) that provides details on the execution path chosen for each lookup because it is too noisy and drastically degrades performance.
 * Fixed a bug in the way that Concourse Server determined if duplicate data existed in the v3 storage files, which caused the `concourse data repair` CLI to no longer work properly (compared to how it worked on the v2 storage files).
+* Fixed a regression that caused a memory leak when data values were read from disk. The nature of the memory leak caused a degradation in performance because Concourse Server was forced to evict cached records from memory more frequently than in previous versions.
 
 #### Version 0.11.1 (March 9, 2022)
 * Upgraded to CCL version `3.1.2` to fix a regression that caused parenthetical expressions within a Condition containing `LIKE` `REGEX`, `NOT_LIKE` and `NOT_REGEX` operators to mistakenly throw a `SyntaxException` when being parsed.

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Value.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Value.java
@@ -100,8 +100,8 @@ public final class Value implements Byteable, Comparable<Value> {
      */
     public static Value fromByteBuffer(ByteBuffer bytes) {
         Type type = Type.values()[bytes.get()];
-        TObject data = extractTObjectAndCache(bytes, type);
-        return new Value(data, bytes);
+        TObject data = createTObject(bytes, type);
+        return new Value(data);
     }
 
     /**
@@ -162,7 +162,7 @@ public final class Value implements Byteable, Comparable<Value> {
      * @param type
      * @return the TObject
      */
-    private static TObject extractTObjectAndCache(ByteBuffer bytes, Type type) {
+    private static TObject createTObject(ByteBuffer bytes, Type type) {
         // Must allocate a heap buffer because TObject assumes it has a
         // backing array and because of THRIFT-2104 that buffer must wrap a
         // byte array in order to assume that the TObject does not lose data
@@ -189,13 +189,6 @@ public final class Value implements Byteable, Comparable<Value> {
 
     /**
      * A cached copy of the binary representation that is returned from
-     * {@link #getBytes()}.
-     */
-    @Nullable
-    private transient ByteBuffer bytes = null;
-
-    /**
-     * A cached copy of the binary representation that is returned from
      * {@link #getCanonicalBytes()}.
      */
     @Nullable
@@ -219,20 +212,10 @@ public final class Value implements Byteable, Comparable<Value> {
      * Construct a new instance.
      * 
      * @param data
-     */
-    private Value(TObject data) {
-        this(data, null);
-    }
-
-    /**
-     * Construct a new instance.
-     * 
-     * @param data
      * @param bytes
      */
-    private Value(TObject data, @Nullable ByteBuffer bytes) {
+    private Value(TObject data) {
         this.data = data;
-        this.bytes = bytes;
     }
 
     @Override
@@ -295,8 +278,8 @@ public final class Value implements Byteable, Comparable<Value> {
 
     @Override
     public void copyTo(ByteSink sink) {
-        sink.put((byte) data.getType().ordinal());
-        sink.put(data.bufferForData());
+        sink.put((byte) data.getType().ordinal()); // type
+        sink.put(data.bufferForData()); // data
     }
 
     @Override
@@ -332,24 +315,6 @@ public final class Value implements Byteable, Comparable<Value> {
         else {
             return equals(obj);
         }
-    }
-
-    /**
-     * Return a byte buffer that represents this Value with the following order:
-     * <ol>
-     * <li><strong>type</strong> - position 0</li>
-     * <li><strong>data</strong> - position 1</li>
-     * </ol>
-     * 
-     * @return the ByteBuffer representation
-     */
-    @Override
-    public ByteBuffer getBytes() {
-        if(bytes == null) {
-            bytes = Byteable.super.getBytes();
-            bytes.rewind();
-        }
-        return ByteBuffers.asReadOnlyBuffer(bytes);
     }
 
     @Override


### PR DESCRIPTION
Fixed a regression that caused a memory leak when data values were read from disk. The nature of the memory leak caused a degradation in performance because Concourse Server was forced to evict cached records from memory more frequently than in previous versions.