### PR TITLE
Added support for querying on Record ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Version 0.11.3 (TBD)
 * Fixed a bug that caused Concourse Server to not use the `Strategy` framework to determine the most efficient lookup source (e.g., field, record, or index) for navigation keys.
+* Added support for querying on the intrinsic `identifier` of Records, as both a selection and evaluation key. The record identifier can be refernced using the `$id$` key (NOTE: this must be properly escaped in `concourse shell` as `\$id\$`). 
+	* It is useful to include the Record identifier as a selection key for some navigation reads (e.g., `select(["partner.name", parner.\$id\$], 1)`)).
+	* It is useful to include the Record identifier as an evaluation key in cases where you want to explictly exclude a record from matching a `Condition` (e.g., `select(["partner.name", parner.\$id\$], "\$id\$ != 2")`))
 
 #### Version 0.11.2 (March 18, 2022)
 * Fixed a bug that caused Concourse Server to incorrectly detect when an attempt was made to atomically commit multiple Writes that toggle the state of a field (e.g. `ADD name as jeff in 1`, `REMOVE name as jeff in 1`, `ADD name as jeff in 1`) in user-defined `transactions`. As a result of this bug, all field toggling Writes were committed instead of the desired behaviour where there was a commit of at most one equal Write that was required to obtain the intended field state. Committing multiple writes that toggled the field state within the same transaction could cause failures, unexplained results or fatal inconsistencies when reconciling data.

--- a/concourse-integration-tests/src/test/java/com/cinchapi/concourse/ReadRecordIdentifierTest.java
+++ b/concourse-integration-tests/src/test/java/com/cinchapi/concourse/ReadRecordIdentifierTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2013-2022 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.concourse;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.cinchapi.concourse.test.ConcourseIntegrationTest;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Unit tests for querying on record identifiers.
+ *
+ * @author Jeff Nelson
+ */
+public class ReadRecordIdentifierTest extends ConcourseIntegrationTest {
+
+    private final String key = Constants.JSON_RESERVED_IDENTIFIER_NAME;
+
+    @Override
+    public void beforeEachTest() {
+        client.add("name", "Jeff Nelson", 1);
+        client.add("name", "Ashleah Nelson", 2);
+        client.add("name", "Reginald Moore", 3);
+        client.add("name", "Aevyn Nelson", 4);
+    }
+
+    @Test
+    public void testSelectionKey() {
+        Set<Long> data = client.select(key, 1);
+        Assert.assertEquals(ImmutableSet.of(1L), data);
+    }
+
+    @Test
+    public void testSelectionKeyCcl() {
+        Map<Long, Set<Long>> data = client.select(key, "name like %Nelson%");
+        data.forEach((key, values) -> {
+            Assert.assertEquals(ImmutableSet.of(key), values);
+        });
+    }
+
+    @Test
+    public void testNavigationSelectionKey() {
+        client.link("spouse", 2, 1);
+        client.link("spouse", 1, 2);
+        Map<String, Set<Object>> data = client.select(
+                ImmutableSet.of("name", "spouse.name", "spouse.$id$"), 1);
+        Assert.assertEquals(ImmutableSet.of(2L), data.get("spouse.$id$"));
+    }
+
+    @Test
+    public void testEvaluationKey() {
+        Set<Long> data = client.find("name like %Nelson% and $id$ != 1");
+        Assert.assertFalse(data.contains(1L));
+    }
+
+    @Test
+    @Ignore // requires CCL bug fix
+    public void testNavigationEvaluationKey() {
+        Set<Long> data = client.find("name like %Nelson% and spouse.$id$ != 1");
+        Assert.assertFalse(data.contains(2L));
+    }
+
+}

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Stores.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Stores.java
@@ -29,6 +29,7 @@ import com.cinchapi.ccl.type.function.KeyRecordsFunction;
 import com.cinchapi.ccl.type.function.TemporalFunction;
 import com.cinchapi.common.base.ArrayBuilder;
 import com.cinchapi.common.reflect.Reflection;
+import com.cinchapi.concourse.Constants;
 import com.cinchapi.concourse.server.calculate.Calculations;
 import com.cinchapi.concourse.server.ops.Strategy.Source;
 import com.cinchapi.concourse.server.query.Finder;
@@ -115,6 +116,10 @@ public final class Stores {
                 throw new UnsupportedOperationException(
                         "Cannot browse the current values of a navigation key using a Store that does not support atomic operations");
             }
+        }
+        else if(key.equals(Constants.JSON_RESERVED_IDENTIFIER_NAME)) {
+            return store.getAllRecords().stream().collect(Collectors.toMap(
+                    Convert::javaToThrift, record -> ImmutableSet.of(record)));
         }
         else {
             return timestamp == Time.NONE ? store.browse(key)
@@ -302,6 +307,9 @@ public final class Stores {
                     evalFunc.key(), record, timestamp, store);
             return value != null ? ImmutableSet.of(Convert.javaToThrift(value))
                     : ImmutableSet.of();
+        }
+        else if(key.equals(Constants.JSON_RESERVED_IDENTIFIER_NAME)) {
+            return ImmutableSet.of(Convert.javaToThrift(record));
         }
         else {
             Source source;


### PR DESCRIPTION
…as both a selection and evaluation key. The record identifier can be refernced using the `$id$` key (NOTE: this must be properly escaped in `concourse shell` as `\$id\$`).

	* It is useful to include the Record identifier as a selection key for some navigation reads (e.g., `select(["partner.name", parner.\$id\$], 1)`)).
	* It is useful to include the Record identifier as an evaluation key in cases where you want to explictly exclude a record from matching a `Condition` (e.g., `select(["partner.name", parner.\$id\$], "\$id\$ != 2")`))