### PR TITLE
Fix significant write performance regression

### DIFF
--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/concurrent/LockBroker.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/concurrent/LockBroker.java
@@ -719,7 +719,6 @@ public class LockBroker {
                                 }
                             }
                         }
-
                     }
                     List<AtomicInteger> undos = new ArrayList<>(1);
                     for (Range<Value> range : token.ranges()) {

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Ranges.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Ranges.java
@@ -196,8 +196,8 @@ public final class Ranges {
         if(lower >= 0 && upper <= 0) {
             start = getLowerEndpoint(a);
             startBound = getLowerBoundType(a);
-            end = getUpperEndpoint(b);
-            endBound = getUpperBoundType(b);
+            end = getUpperEndpoint(a);
+            endBound = getUpperBoundType(a);
         }
         else if(lower <= 0 && upper >= 0) {
             start = getLowerEndpoint(b);

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Ranges.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Ranges.java
@@ -176,6 +176,29 @@ public final class Ranges {
     }
 
     /**
+     * Return {@code true} if {@code a} {@link Range#isConnected(Range) is
+     * connected to} {@code b} and the {@link Range#intersection(Range)
+     * intersection} of the two is not {@link Range#isEmpty() empty}.
+     * 
+     * @param a
+     * @param b
+     * @return {@code true} if {@code a} and {@code b} are connected and have a
+     *         non-empty intersection
+     */
+    public static boolean haveNonEmptyIntersection(Range<Value> a,
+            Range<Value> b) {
+        int lower = compareToLower(a, b);
+        int upper = compareToUpper(a, b);
+        if((lower > 0 && upper > 0) || (lower < 0 && upper < 0)) {
+            return false;
+        }
+        else {
+            return !(getLowerEndpoint(a).equals(getLowerEndpoint(b))
+                    && upper == 0);
+        }
+    }
+
+    /**
      * Return a new {@link Range} that is the merger (e.g. union) of {@code a}
      * and {@code b}. The new {@link Range} maintains both the lower and higher
      * endpoint/bound between the two inputs.

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Ranges.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/model/Ranges.java
@@ -189,13 +189,32 @@ public final class Ranges {
             Range<Value> b) {
         int lower = compareToLower(a, b);
         int upper = compareToUpper(a, b);
-        if((lower > 0 && upper > 0) || (lower < 0 && upper < 0)) {
-            return false;
+        Value start;
+        Value end;
+        BoundType startBound;
+        BoundType endBound;
+        if(lower >= 0 && upper <= 0) {
+            start = getLowerEndpoint(a);
+            startBound = getLowerBoundType(a);
+            end = getUpperEndpoint(b);
+            endBound = getUpperBoundType(b);
+        }
+        else if(lower <= 0 && upper >= 0) {
+            start = getLowerEndpoint(b);
+            startBound = getLowerBoundType(b);
+            end = getUpperEndpoint(b);
+            endBound = getUpperBoundType(b);
         }
         else {
-            return !(getLowerEndpoint(a).equals(getLowerEndpoint(b))
-                    && upper == 0);
+            start = lower >= 0 ? getLowerEndpoint(a) : getLowerEndpoint(b);
+            startBound = lower >= 0 ? getLowerBoundType(a)
+                    : getLowerBoundType(b);
+            end = upper <= 0 ? getUpperEndpoint(a) : getUpperEndpoint(b);
+            endBound = upper <= 0 ? getUpperBoundType(a) : getUpperBoundType(b);
         }
+        int c = start.compareTo(end);
+        return c < 0 || (c == 0 && startBound == BoundType.CLOSED
+                && endBound == BoundType.CLOSED);
     }
 
     /**

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/concurrent/LockBrokerTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/concurrent/LockBrokerTest.java
@@ -336,7 +336,6 @@ public class LockBrokerTest extends ConcourseBaseTest {
         t.start();
         startLatch.await();
         Value value3 = Variables.register("value3", decrease(value1));
-        broker.tryWriteLock(RangeToken.forWriting(key, value3));
         Assert.assertNotNull(
                 broker.tryWriteLock(RangeToken.forWriting(key, value3)));
         finishLatch.countDown();
@@ -1077,6 +1076,17 @@ public class LockBrokerTest extends ConcourseBaseTest {
         b.release();
         Assert.assertNull(broker.tryWriteLock(token));
         a.release();
+    }
+
+    @Test
+    public void testRangeWriteLockIsExclusive() {
+        Text key = Text.wrap("foo");
+        Value value = Value.wrap(Convert.javaToThrift(1));
+        RangeToken token = RangeToken.forWriting(key, value);
+        Permit a = broker.writeLock(token);
+        Assert.assertNull(broker.tryWriteLock(token));
+        a.release();
+        Assert.assertNotNull(broker.tryWriteLock(token));
     }
 
     private Value decrease(Value value) {

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/model/RangesTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/model/RangesTest.java
@@ -48,6 +48,60 @@ public class RangesTest {
         Assert.assertEquals(expected, Ranges.haveNonEmptyIntersection(a, b));
     }
 
+    @Test
+    public void testHaveNonEmptyIntersectionReproA() {
+        Range<Value> a = Range.closedOpen(
+                Value.wrap(Convert.javaToThrift(-1307906851)),
+                Value.wrap(Convert.javaToThrift(740542968)));
+        Range<Value> b = Range.closedOpen(
+                Value.wrap(Convert.javaToThrift(255904862)),
+                Value.wrap(Convert.javaToThrift(1010153814)));
+        boolean expected;
+        try {
+            expected = !a.intersection(b).isEmpty();
+        }
+        catch (IllegalArgumentException e) {
+            expected = false;
+        }
+        Assert.assertEquals(expected, Ranges.haveNonEmptyIntersection(a, b));
+    }
+
+    @Test
+    public void testHaveNonEmptyIntersectionReproB() {
+        Range<Value> a = Range.closedOpen(
+                Value.wrap(Convert.javaToThrift(-14136856)),
+                Value.wrap(Convert.javaToThrift(1519386470)));
+        Range<Value> b = Range.closed(
+                Value.wrap(Convert.javaToThrift(879784252)),
+                Value.wrap(Convert.javaToThrift(879784252)));
+        boolean expected;
+        try {
+            expected = !a.intersection(b).isEmpty();
+        }
+        catch (IllegalArgumentException e) {
+            expected = false;
+        }
+        Assert.assertEquals(expected, Ranges.haveNonEmptyIntersection(a, b));
+    }
+
+    @Test
+    public void testHaveNonEmptyIntersectionReproC() {
+        Range<Value> a = Range.closedOpen(
+                Value.wrap(Convert.javaToThrift(-2114795584)),
+                Value.wrap(Convert.javaToThrift(2012556173)));
+        Range<Value> b = Range.closed(
+                Value.wrap(Convert.javaToThrift(1307191844)),
+                Value.wrap(Convert.javaToThrift(1307191844)));
+        boolean expected;
+        try {
+            expected = !a.intersection(b).isEmpty();
+        }
+        catch (IllegalArgumentException e) {
+            expected = false;
+        }
+        Assert.assertEquals(expected, Ranges.haveNonEmptyIntersection(a, b));
+    }
+
     /**
      * Return a random {@link Range}.
      * 

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/model/RangesTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/model/RangesTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2013-2022 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.concourse.server.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cinchapi.concourse.server.concurrent.RangeToken;
+import com.cinchapi.concourse.thrift.Operator;
+import com.cinchapi.concourse.util.Convert;
+import com.cinchapi.concourse.util.Numbers;
+import com.cinchapi.concourse.util.TestData;
+import com.google.common.collect.Range;
+
+/**
+ * Unit tests for {@link Ranges}.
+ *
+ * @author Jeff Nelson
+ */
+public class RangesTest {
+
+    @Test
+    public void testHaveNonEmptyIntersection() {
+        Range<Value> a = randomRange();
+        Range<Value> b = randomRange();
+        System.out.println(a);
+        System.out.println(b);
+        boolean expected;
+        try {
+            expected = !a.intersection(b).isEmpty();
+        }
+        catch (IllegalArgumentException e) {
+            expected = false;
+        }
+        Assert.assertEquals(expected, Ranges.haveNonEmptyIntersection(a, b));
+    }
+
+    /**
+     * Return a random {@link Range}.
+     * 
+     * @return the {@link Range}
+     */
+    private static Range<Value> randomRange() {
+        int a = TestData.getInt();
+        int b = TestData.getInt();
+        Value low = Value.wrap(Convert.javaToThrift(Math.min(a, b)));
+        Value high = Value.wrap(Convert.javaToThrift(Math.max(a, b)));
+        Text key = TestData.getText();
+        int c = TestData.getScaleCount();
+        RangeToken token;
+        if(c % 3 == 0) {
+            token = RangeToken.forReading(key, Operator.BETWEEN, low, high);
+        }
+        else if(c % 4 == 0) {
+            boolean d = Numbers.isEven(TestData.getScaleCount());
+            boolean e = Numbers.isEven(TestData.getScaleCount());
+            Operator operator;
+            if(d & e) {
+                operator = Operator.GREATER_THAN_OR_EQUALS;
+            }
+            else if(d & !e) {
+                operator = Operator.GREATER_THAN;
+            }
+            else if(!d & e) {
+                operator = Operator.LESS_THAN_OR_EQUALS;
+            }
+            else {
+                operator = Operator.LESS_THAN;
+            }
+            token = RangeToken.forReading(key, operator, low);
+        }
+        else {
+            token = RangeToken.forWriting(key, high);
+        }
+        return token.ranges().iterator().next();
+    }
+
+}


### PR DESCRIPTION
GC locked ranges in LockBroker so performance doesn't degrade over time and also be more intelligent about when to check every locked range for blocking