### PR TITLE
Advisory Locking in the Engine

### DIFF
--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/concurrent/Locks.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/concurrent/Locks.java
@@ -16,6 +16,7 @@
 package com.cinchapi.concourse.server.concurrent;
 
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -49,6 +50,17 @@ public final class Locks {
      */
     public static ReadLock noOpReadLock() {
         return NOOP_READ_LOCK;
+    }
+
+    /**
+     * Return a {@link ReadWriteLock} that is non-operational and always returns
+     * immediately without actually acquiring and shared or exclusive holds on
+     * any monitor.
+     * 
+     * @return the noop {@link ReadWriteLock}
+     */
+    public static ReadWriteLock noOpReadWriteLock() {
+        return NOOP_READ_WRITE_LOCK;
     }
 
     /**
@@ -207,6 +219,23 @@ public final class Locks {
 
         @Override
         public void unlock() {}
+    };
+    
+    /**
+     * The lock that is returned by the {@link #noOpReadWriteLock()} method.
+     */
+    private static final ReadWriteLock NOOP_READ_WRITE_LOCK = new ReadWriteLock() {
+
+        @Override
+        public Lock readLock() {
+            return NOOP_READ_LOCK;
+        }
+
+        @Override
+        public Lock writeLock() {
+            return NOOP_WRITE_LOCK;
+        }
+
     };
 
 }

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/concurrent/Locks.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/concurrent/Locks.java
@@ -220,7 +220,7 @@ public final class Locks {
         @Override
         public void unlock() {}
     };
-    
+
     /**
      * The lock that is returned by the {@link #noOpReadWriteLock()} method.
      */

--- a/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Stores.java
+++ b/concourse-server/src/main/java/com/cinchapi/concourse/server/ops/Stores.java
@@ -309,31 +309,33 @@ public final class Stores {
             Map<String, Set<TObject>> stored = null;
             Node root = null;
             int count = 1;
-            for (String key : keys) {
-                Key metadata = Keys.parse(key);
-                KeyType type = metadata.type();
-                if(type == KeyType.NAVIGATION_KEY) {
-                    // Generate a single Graph containing all of the stops in
-                    // each of the navigation keys.
-                    root = root == null ? Node.root(record) : root;
-                    Node node = root;
-                    String[] stops = metadata.data();
-                    for (String stop : stops) {
-                        node = node.next(stop);
-                        ++count;
+            store.advisoryLock().readLock().lock();
+            try {
+                for (String key : keys) {
+                    Key metadata = Keys.parse(key);
+                    KeyType type = metadata.type();
+                    if(type == KeyType.NAVIGATION_KEY) {
+                        // Generate a single Graph containing all of the stops
+                        // in each of the navigation keys.
+                        root = root == null ? Node.root(record) : root;
+                        Node node = root;
+                        String[] stops = metadata.data();
+                        for (String stop : stops) {
+                            node = node.next(stop);
+                            ++count;
+                        }
+                        node.end();
                     }
-                    node.end();
-                }
-                else {
-                    Set<TObject> values;
-                    if(type == KeyType.WRITABLE_KEY && keys.size() == 1) {
-                        // Since there is only one key and it is writable, tap
-                        // into the Strategy framework to determine the most
-                        // efficient lookup source.
-                        return ImmutableMap.of(key, lookupWithStrategy(store,
-                                key, record, timestamp));
-                    }
-                    else if(type == KeyType.WRITABLE_KEY) {
+                    else {
+                        Set<TObject> values;
+                        if(type == KeyType.WRITABLE_KEY && keys.size() == 1) {
+                            // Since there is only one key and it is writable,
+                            // tap into the Strategy framework to determine the
+                            // most efficient lookup source.
+                            return ImmutableMap.of(key, lookupWithStrategy(
+                                    store, key, record, timestamp));
+                        }
+                        else if(type == KeyType.WRITABLE_KEY) {
                         // @formatter:off
                         stored = stored == null
                                 ? (timestamp == Time.NONE 
@@ -342,81 +344,94 @@ public final class Stores {
                                   )
                                 : stored;
                         // @formatter:on
-                        values = stored.get(key);
-                        if(values == null) {
+                            values = stored.get(key);
+                            if(values == null) {
+                                values = ImmutableSet.of();
+                            }
+                        }
+                        else if(type == KeyType.IDENTIFIER_KEY) {
+                            values = ImmutableSet
+                                    .of(Convert.javaToThrift(record));
+                        }
+                        else if(type == KeyType.FUNCTION_KEY) {
+                            Function function = metadata.data();
+                            String method = Calculations.alias(
+                                    function.operation()) + "KeyRecordAtomic";
+                            Number value = Reflection.callStatic(
+                                    Operations.class, method, function.key(),
+                                    record, timestamp, store);
+                            values = value != null
+                                    ? ImmutableSet
+                                            .of(Convert.javaToThrift(value))
+                                    : ImmutableSet.of();
+                        }
+                        else {
                             values = ImmutableSet.of();
                         }
+                        data.put(key, values);
                     }
-                    else if(type == KeyType.IDENTIFIER_KEY) {
-                        values = ImmutableSet.of(Convert.javaToThrift(record));
-                    }
-                    else if(type == KeyType.FUNCTION_KEY) {
-                        Function function = metadata.data();
-                        String method = Calculations.alias(function.operation())
-                                + "KeyRecordAtomic";
-                        Number value = Reflection.callStatic(Operations.class,
-                                method, function.key(), record, timestamp,
-                                store);
-                        values = value != null
-                                ? ImmutableSet.of(Convert.javaToThrift(value))
-                                : ImmutableSet.of();
-                    }
-                    else {
-                        values = ImmutableSet.of();
-                    }
-                    data.put(key, values);
                 }
-            }
-            if(root != null) {
-                // Iterate through the graph, in a breadth-first manner, to
-                // perform bulk selection at each Junctions.
-                Queue<Node> queue = new ArrayDeque<>(count);
-                queue.add(root);
-                while (!queue.isEmpty()) {
-                    Node node = queue.poll();
-                    Collection<Node> successors = node.successors();
-                    if(successors.isEmpty()) {
-                        data.put(node.path, node.values());
-                    }
-                    else {
-                        queue.addAll(successors);
-                        Collection<Long> links = node.links();
-                        for (long link : links) {
-                            Map<String, Set<TObject>> intermediate = null;
-                            if(successors.size() > 1) {
-                                // Bypassing the Strategy framework is
-                                // acceptable here because we know that there
-                                // are multiple keys that need to be selected
-                                // from each record, so it makes sense to select
-                                // the entire record from the Engine, once
-                                intermediate = timestamp == Time.NONE
-                                        ? store.select(link)
-                                        : store.select(link, timestamp);
-                            }
-                            for (Node successor : successors) {
-                                String stop = successor.stop;
-                                if(intermediate == null) {
-                                    // This means there is only 1 successor, so
-                                    // the lookup should defer to the Strategy
-                                    // framework
-                                    intermediate = ImmutableMap.of(stop,
-                                            lookupWithStrategy(store, stop,
-                                                    link, timestamp));
+                if(root != null) {
+                    // Iterate through the graph, in a breadth-first manner, to
+                    // perform bulk selection at each Junctions.
+                    Queue<Node> queue = new ArrayDeque<>(count);
+                    queue.add(root);
+                    while (!queue.isEmpty()) {
+                        Node node = queue.poll();
+                        Collection<Node> successors = node.successors();
+                        if(successors.isEmpty()) {
+                            data.put(node.path, node.values());
+                        }
+                        else {
+                            queue.addAll(successors);
+                            Collection<Long> links = node.links();
+                            for (long link : links) {
+                                Map<String, Set<TObject>> intermediate = null;
+                                if(successors.size() > 1) {
+                                    // Bypassing the Strategy framework is
+                                    // acceptable here because we know that
+                                    // there are multiple keys that need to be
+                                    // selected from each record, so it makes
+                                    // sense to select the entire record from
+                                    // the Engine, once
+                                    intermediate = timestamp == Time.NONE
+                                            ? store.select(link)
+                                            : store.select(link, timestamp);
                                 }
-                                Set<TObject> values = intermediate.get(stop);
-                                if(values != null) {
-                                    successor.store(values);
-                                }
-                                else if(stop.equals(
-                                        Constants.JSON_RESERVED_IDENTIFIER_NAME)) {
-                                    successor.store(Convert.javaToThrift(link));
+                                for (Node successor : successors) {
+                                    String stop = successor.stop;
+                                    if(intermediate == null) {
+                                        // This means there is only 1 successor,
+                                        // so the lookup should defer to the
+                                        // Strategy framework
+                                        intermediate = ImmutableMap.of(stop,
+                                                lookupWithStrategy(store, stop,
+                                                        link, timestamp));
+                                    }
+                                    Set<TObject> values = intermediate
+                                            .get(stop);
+                                    if(values != null) {
+                                        successor.store(values);
+                                    }
+                                    else if(stop.equals(
+                                            Constants.JSON_RESERVED_IDENTIFIER_NAME)) {
+                                        successor.store(
+                                                Convert.javaToThrift(link));
+                                    }
                                 }
                             }
                         }
                     }
                 }
+                // @formatter:off
+                return data.size() > 1
+                        ? new OrderImposingMap<>(keys, data)
+                        : data;
+                // @formatter:on
             }
-            return data.size() > 1 ? new OrderImposingMap<>(keys, data) : data;
+            finally {
+                store.advisoryLock().readLock().unlock();
+            }
         }
     }
 

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/ops/StoresTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/ops/StoresTest.java
@@ -23,16 +23,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.cinchapi.common.profile.Benchmark;
+import com.cinchapi.common.reflect.Reflection;
 import com.cinchapi.concourse.Link;
 import com.cinchapi.concourse.server.ops.Stores.NavigationKeyFinder;
 import com.cinchapi.concourse.server.storage.AtomicSupport;
 import com.cinchapi.concourse.server.storage.Engine;
+import com.cinchapi.concourse.server.storage.temp.Buffer;
 import com.cinchapi.concourse.server.storage.temp.Write;
 import com.cinchapi.concourse.thrift.Operator;
 import com.cinchapi.concourse.thrift.TObject;
@@ -386,6 +390,53 @@ public class StoresTest {
         Map<Long, Map<String, Set<TObject>>> expected = PrettyLinkedTableMap
                 .of(ImmutableMap.of(1L, _expected));
         System.out.println(expected);
+        Assert.assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void testBulkSelectDuringTransports() throws InterruptedException {
+        AtomicSupport store = getStore();
+        Buffer buffer = Reflection.get("limbo", store);
+        
+        AtomicBoolean transportable = new AtomicBoolean(false);
+        while(!transportable.get()) {
+            for(int i = 0; i < TestData.getScaleCount(); ++i) {
+                store.accept(TestData.getWriteAdd());
+            }
+            if(!transportable.get()) {
+                transportable.set(Reflection.call(buffer, "canTransport"));
+            }
+        }
+        setupNavigationGraph(store);
+        List<String> keys = ImmutableList.of(
+                "name",
+                "email",
+                "title",
+                "website",
+                "association"
+        );
+        
+        AtomicBoolean stop = new AtomicBoolean(false);
+        CountDownLatch start = new CountDownLatch(1);
+        
+        Thread writer = new Thread(() -> {
+            while(!stop.get()) {
+                for(int i = 0; i < TestData.getScaleCount(); ++i) {
+                    store.accept(TestData.getWriteAdd());
+                }
+                Stores.select(store, keys, 1);
+                start.countDown();
+            }
+        });
+        writer.start();
+        start.await();
+        
+        Map<String, Set<TObject>> actual = Stores.select(store, keys, 1);
+        Map<String, Set<TObject>> expected = new LinkedHashMap<>();
+        for (String key : keys) {
+            expected.put(key, Stores.serialSelect(store, key, 1));
+        }
+        
         Assert.assertEquals(expected, actual);
     }
 

--- a/concourse-server/src/test/java/com/cinchapi/concourse/server/ops/StoresTest.java
+++ b/concourse-server/src/test/java/com/cinchapi/concourse/server/ops/StoresTest.java
@@ -392,15 +392,15 @@ public class StoresTest {
         System.out.println(expected);
         Assert.assertEquals(expected, actual);
     }
-    
+
     @Test
     public void testBulkSelectDuringTransports() throws InterruptedException {
         AtomicSupport store = getStore();
         Buffer buffer = Reflection.get("limbo", store);
-        
+
         AtomicBoolean transportable = new AtomicBoolean(false);
-        while(!transportable.get()) {
-            for(int i = 0; i < TestData.getScaleCount(); ++i) {
+        while (!transportable.get()) {
+            for (int i = 0; i < TestData.getScaleCount(); ++i) {
                 store.accept(TestData.getWriteAdd());
             }
             if(!transportable.get()) {
@@ -408,20 +408,15 @@ public class StoresTest {
             }
         }
         setupNavigationGraph(store);
-        List<String> keys = ImmutableList.of(
-                "name",
-                "email",
-                "title",
-                "website",
-                "association"
-        );
-        
+        List<String> keys = ImmutableList.of("name", "email", "title",
+                "website", "association");
+
         AtomicBoolean stop = new AtomicBoolean(false);
         CountDownLatch start = new CountDownLatch(1);
-        
+
         Thread writer = new Thread(() -> {
-            while(!stop.get()) {
-                for(int i = 0; i < TestData.getScaleCount(); ++i) {
+            while (!stop.get()) {
+                for (int i = 0; i < TestData.getScaleCount(); ++i) {
                     store.accept(TestData.getWriteAdd());
                 }
                 Stores.select(store, keys, 1);
@@ -430,13 +425,13 @@ public class StoresTest {
         });
         writer.start();
         start.await();
-        
+
         Map<String, Set<TObject>> actual = Stores.select(store, keys, 1);
         Map<String, Set<TObject>> expected = new LinkedHashMap<>();
         for (String key : keys) {
             expected.put(key, Stores.serialSelect(store, key, 1));
         }
-        
+
         Assert.assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
The Engine now allows higher level abstractions to acquire an advisory lock for bulk or atomic operations to block the transporter from impacting reads while those operations are happeing