### PR TITLE
Cache parsed keys for better performance in reads and writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ We made several changes to improve the safety, scalability and operational effic
 
 #### Version 0.11.9 (TBD)
 * Improved the performance of multi-key selection commands that occur during concurrent Buffer transport operations. Previously, when selecting multiple keys while data was being transported for indexing, each primitive select operation would acquire a lock that blocked transports, but transports could still occur between operations, slowing down the overall read. Now, these commands use an advisory lock that blocks all transports until the entire bulk read completes. This optimization significantly improves performance in real-world scenarios with simultaneous reads and writes. In the future, this advisory locking mechanism will be extended to other bulk and atomic operations.
+* Implemented a caching mechanism for parsed keys to eliminate repeated validation and processing throughout the system. Previously, keys (especially navigation keys) were repeatedly validated against the WRITABLE_KEY regex and tokenized for every operation, even when the same keys were used multiple times. This optimization significantly improves performance for all operations that involve key validation and navigation key processing, with particularly noticeable benefits in scenarios that use the same keys repeatedly across multiple records.
 
 #### Version 0.11.8 (April 15, 2025)
 

--- a/concourse-driver-java/src/main/java/com/cinchapi/concourse/validate/Keys.java
+++ b/concourse-driver-java/src/main/java/com/cinchapi/concourse/validate/Keys.java
@@ -15,11 +15,12 @@
  */
 package com.cinchapi.concourse.validate;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 
 import com.cinchapi.ccl.grammar.FunctionKeySymbol;
 import com.cinchapi.ccl.grammar.Symbol;
@@ -29,6 +30,7 @@ import com.cinchapi.ccl.type.Function;
 import com.cinchapi.ccl.type.function.ImplicitKeyRecordFunction;
 import com.cinchapi.concourse.Constants;
 import com.cinchapi.concourse.lang.ConcourseCompiler;
+import com.google.common.base.Preconditions;
 
 /**
  * Utility functions for data keys.
@@ -44,7 +46,7 @@ public final class Keys {
      * @return {@code true} if the provided {@code key} is a function key
      */
     public static boolean isFunctionKey(String key) {
-        return tryParseFunction(key) != null;
+        return parse(key).type() == KeyType.FUNCTION_KEY;
     }
 
     /**
@@ -55,7 +57,7 @@ public final class Keys {
      *         key
      */
     public static boolean isNavigationKey(String key) {
-        return key.indexOf('.') > 0;
+        return parse(key).type() == KeyType.NAVIGATION_KEY;
     }
 
     /**
@@ -65,25 +67,7 @@ public final class Keys {
      * @return {@code true} if the provided {@code key} is valid for writing
      */
     public static boolean isWritable(String key) {
-        if(WRITABLE_KEY_CACHE.contains(key)) {
-            return true;
-        }
-        else {
-            boolean writable = key.length() > 0
-                    && KEY_VALIDATION_REGEX.matcher(key).matches();
-            if(writable) {
-                try {
-                    WRITABLE_KEY_CACHE.add(key);
-                }
-                catch (Exception e) {
-                    // Ignore any concurrency exceptions while modifying the
-                    // non-concurrent collection because failure would just
-                    // cause us to re-validate the key in the future.
-                }
-            }
-            return writable;
-        }
-
+        return parse(key).type() == KeyType.WRITABLE_KEY;
     }
 
     /**
@@ -94,25 +78,27 @@ public final class Keys {
      * @return the parsed {@link Key}
      */
     public static Key parse(String key) {
-        String[] toks;
-        ImplicitKeyRecordFunction func;
-        if(isWritable(key)) {
-            return new Key(key, KeyType.WRITABLE_KEY, key);
-        }
-        else if(key.equals(Constants.JSON_RESERVED_IDENTIFIER_NAME)) {
-            return new Key(key, KeyType.IDENTIFIER_KEY, key);
-        }
-        else {
-            toks = key.split("\\.");
-            if(toks.length > 1) {
-                return new Key(key, KeyType.NAVIGATION_KEY, toks);
+        Preconditions.checkArgument(key != null, "Cannot parse a null key");
+        return CACHE.computeIfAbsent(key, $ -> {
+            if(key.length() > 0
+                    && KEY_VALIDATION_REGEX.matcher(key).matches()) {
+                return new Key(key, KeyType.WRITABLE_KEY, key);
             }
-            func = tryParseFunction(key);
-            if(func != null) {
-                return new Key(key, KeyType.FUNCTION_KEY, func);
+            else if(key.equals(Constants.JSON_RESERVED_IDENTIFIER_NAME)) {
+                return new Key(key, KeyType.IDENTIFIER_KEY, key);
             }
-            return new Key(key, KeyType.INVALID_KEY, key);
-        }
+            else {
+                String[] toks = key.split("\\.");
+                if(toks.length > 1) {
+                    return new Key(key, KeyType.NAVIGATION_KEY, toks);
+                }
+                ImplicitKeyRecordFunction func = tryParseFunction(key);
+                if(func != null) {
+                    return new Key(key, KeyType.FUNCTION_KEY, func);
+                }
+                return new Key(key, KeyType.INVALID_KEY, key);
+            }
+        });
     }
 
     /**
@@ -141,21 +127,18 @@ public final class Keys {
     }
 
     /**
+     * A global set of all inquired about keys and the information parsed about
+     * them.
+     */
+    private static final Map<String, Key> CACHE = new ConcurrentHashMap<>(100);
+
+    /**
      * A pre-compiled regex pattern that is used to validate that each key is
      * non-empty, alphanumeric with no special characters other than underscore
      * (_).
      */
     private static final Pattern KEY_VALIDATION_REGEX = Pattern
             .compile("^[a-zA-Z0-9_]+$");
-
-    /**
-     * A global set of all {@link String Strings} known to be
-     * {@link #isWritable(String) writable} keys.
-     */
-    // We aren't concerned about thread safety here because items are never
-    // removed from the cache and spurious lookup failure would merely trigger
-    // manual validation.
-    private static final Set<String> WRITABLE_KEY_CACHE = new HashSet<>(100);
 
     private Keys() {/* no-init */}
 
@@ -166,6 +149,7 @@ public final class Keys {
      *
      * @author Jeff Nelson
      */
+    @Immutable
     public static final class Key {
 
         /**
@@ -211,6 +195,11 @@ public final class Keys {
             return (T) data;
         }
 
+        @Override
+        public String toString() {
+            return value;
+        }
+
         /**
          * Return the {@link KeyType}.
          * 
@@ -226,11 +215,6 @@ public final class Keys {
          * @return the value
          */
         public String value() {
-            return value;
-        }
-
-        @Override
-        public String toString() {
             return value;
         }
 


### PR DESCRIPTION
ConcourseServer has to often check if keys are writable or are navigation keys, etc to faciliate writes and real world navigable reads. Previously we cached known writable keys, but we still paid a penalty for navigation keys that were repeatedly both checked againist the WRITABLE_KEY regex and then tokenized. If we were selecting multiple navigation keys for multiple records these keys went through the same validation logic EVERY SINGLE TIME. This update just caches the results of Key parsing and defers all method paths to use Key parsing so checks are more efficient in real world scenarios